### PR TITLE
Add travis ci gitter build channel integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: crystal
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/4e749ae6ae5baf9a4131
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
This will allowing anyone who is contributing to receive status on PR
build and merges.

The travis yml has been updated to include a webhook supported by
gitter.

Whith this PR now the community can stay in sync with Amber build
progress.