### PR TITLE
Changed webhook endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: crystal
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/4e749ae6ae5baf9a4131
+      - https://webhooks.gitter.im/e/aaf02221d4649d70b384
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
The previous endpoint for the YAML file was incorrect. 

The new endpoint is a valid endpoint and sends a notification to the Lobby channel on gitter.

I think to have notifications in gitter is a good idea this was people are aware of the project activity