### PR TITLE
added multipart form support and tests

### DIFF
--- a/spec/amber/pipe/params_spec.cr
+++ b/spec/amber/pipe/params_spec.cr
@@ -87,6 +87,19 @@ module Amber
 
         context.params["_json"].should eq "[\"test\", \"test2\"]"
       end
+
+      it "parses files from multipart forms" do
+        headers = HTTP::Headers.new
+        headers["Content-Type"] = "multipart/form-data; boundary=fhhRFLCazlkA0dX"
+        body = "--fhhRFLCazlkA0dX\r\nContent-Disposition: form-data; name=\"_csrf\"\r\n\r\nPcCFp4oKJ1g-hZ-P7-phg0alC51pz7Pl12r0ZOncgxI\r\n--fhhRFLCazlkA0dX\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\ntitle field\r\n--fhhRFLCazlkA0dX\r\nContent-Disposition: form-data; name=\"picture\"; filename=\"index.html\"\r\nContent-Type: text/html\r\n\r\n<head></head><body>Hello World!</body>\r\n\r\n--fhhRFLCazlkA0dX\r\nContent-Disposition: form-data; name=\"content\"\r\n\r\nseriously\r\n--fhhRFLCazlkA0dX--"
+        request = HTTP::Request.new("POST", "/", headers, body)
+        context = create_context(request)
+        params = Params.instance
+        params.call(context)
+        context.files["picture"].filename.should eq "index.html"
+        context.params["title"].should eq "title field"
+        context.params["_csrf"].should eq "PcCFp4oKJ1g-hZ-P7-phg0alC51pz7Pl12r0ZOncgxI"
+      end
     end
   end
 end

--- a/src/amber/context.cr
+++ b/src/amber/context.cr
@@ -15,6 +15,14 @@ class HTTP::Server::Context
     @params ||= HTTP::Params.new({} of String => Array(String))
   end
 
+  def clear_files
+    @files = {} of String => UploadedFile
+  end
+
+  def files
+    @files ||= {} of String => UploadedFile
+  end
+
   # clear the session.  You can call this to logout a user.
   def clear_session
     @session = {} of String => String

--- a/src/amber/uploaded_file.cr
+++ b/src/amber/uploaded_file.cr
@@ -1,0 +1,23 @@
+require "tempfile"
+
+struct UploadedFile
+  getter file : Tempfile
+  getter filename : String?
+  getter headers : HTTP::Headers
+  getter creation_time : Time?
+  getter modification_time : Time?
+  getter read_time : Time?
+  getter size : UInt64?
+
+  def initialize(upload)
+    @filename = upload.filename
+    @file = Tempfile.open(@filename) do |file|
+      IO.copy(upload.body, file)
+    end
+    @headers = upload.headers
+    @creation_time = upload.creation_time
+    @modification_time = upload.modification_time
+    @read_time = upload.read_time
+    @size = upload.size
+  end
+end


### PR DESCRIPTION
### Description of the Change

Files and other multipart data is now being parsed. Normal params from form-data are added to `context.params` while files are added to `context.files`.

### Alternate Designs

I tried adding files to `context.params` but would have had to override a lot of base level code to add uploaded files to HTTP::Params.

### Why Should This Be In Core?

Multipart form data is very common and any framework that parses params should parse them from multipart forms as well.

### Benefits

You can upload files now.

