### PR TITLE
Moves DSLs to dsl module

### DIFF
--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -1,4 +1,4 @@
-module Amber::Support::DSL
+module Amber::DSL
   record Pipeline, pipeline : Pipe::Pipeline do
     def plug(pipe)
       pipeline.plug pipe

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -28,7 +28,7 @@ module Amber
       def build(valve : Symbol, &block)
         @valve = valve
         @pipeline[@valve] = [] of HTTP::Handler unless @pipeline.key? @valve
-        with Support::DSL::Pipeline.new(self) yield
+        with DSL::Pipeline.new(self) yield
       end
 
       def plug(pipe : HTTP::Handler)

--- a/src/amber/router/pipe/router.cr
+++ b/src/amber/router/pipe/router.cr
@@ -26,7 +26,7 @@ module Amber
 
       # This registers all the routes for the application
       def draw
-        with Support::DSL::Router.new(self) yield
+        with DSL::Router.new(self) yield
       end
 
       def add(route : Route)


### PR DESCRIPTION
## Improves Dir Structure

### Requirements

In an effort to move to a better directory structure this PR comes to move DSLs into its own directory. 

### Description of the Change

- Moves DSLs out of support module
- Creates DSL dir for all amber DSL modules
- Improves code organization

### Benefits

More Intuitive code structure
