### PR TITLE
Routing Scope and Through parameters to routes.

### DIFF
--- a/examples/src/controller/hello_controller.cr
+++ b/examples/src/controller/hello_controller.cr
@@ -17,8 +17,7 @@ class HelloController < Amber::Controller::Base
 
   def world
     if params.valid?
-      # "Welcome to planet: #{params["planet"]}!"
-      "Valid!"
+      "Welcome to planet: #{params["planet"]}!"
     else
       "There is no world defined!"
     end

--- a/examples/src/demo.cr
+++ b/examples/src/demo.cr
@@ -43,14 +43,17 @@ MY_APP_SERVER.config do |app|
   # HTTP methods supported [GET, PATCH, POST, PUT, DELETE, OPTIONS]
   # Read more about HTTP methods here
   # (HTTP METHODS)[https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html]
-  routes do
+  routes :static do
     # Each route is defined as follow
     # verb, resources : String, controller : Symbol, action : Symbol,
     # pipeline : Symbol
-    get "/*", StaticController, :index, :static
-    get "/hello", HelloController, :index, :web
-    get "/hello/:planet", HelloController, :world, :web
-    get "/hello/template", HelloController, :template, :web
+    get "/*", StaticController, :index
+  end
+
+  routes :web, "/v2" do
+    get "/hello", HelloController, :index
+    get "/hello/:planet", HelloController, :world
+    get "/hello/template", HelloController, :template
   end
 end
 

--- a/spec/amber/router/pipe/router_spec.cr
+++ b/spec/amber/router/pipe/router_spec.cr
@@ -17,8 +17,8 @@ module Amber
           router = Router.instance
           request = HTTP::Request.new("GET", "/index/elias")
 
-          router.draw do
-            get "/index/:name", HelloController, :world, :web
+          router.draw :web do
+            get "/index/:name", HelloController, :world
           end
 
           response = create_request_and_return_io(router, request)
@@ -50,8 +50,8 @@ module Amber
           router = Router.instance
           request = HTTP::Request.new("GET", "/checkout/elias")
 
-          router.draw do
-            get "/checkout/:name", HelloController, :world, :web
+          router.draw :web do
+            get "/checkout/:name", HelloController, :world
           end
 
           route = Router.instance.match_by_request(request)

--- a/spec/amber_spec.cr
+++ b/spec/amber_spec.cr
@@ -14,23 +14,23 @@ describe Amber do
         secret = "some secret key"
 
         pipeline :api do
-          plug Amber::Pipe::Params.instance
-          plug Amber::Pipe::Logger.instance
-          plug Amber::Pipe::Error.instance
-          plug Amber::Pipe::Session.instance
+          plug Amber::Pipe::Params.new
+          plug Amber::Pipe::Logger.new
+          plug Amber::Pipe::Error.new
+          plug Amber::Pipe::Session.new
         end
 
         pipeline :static do
-          plug Amber::Pipe::Params.instance
-          plug Amber::Pipe::Logger.instance
-          plug Amber::Pipe::Error.instance
-          plug Amber::Pipe::Session.instance
+          plug Amber::Pipe::Params.new
+          plug Amber::Pipe::Logger.new
+          plug Amber::Pipe::Error.new
+          plug Amber::Pipe::Session.new
         end
 
-        routes do
-          get "/", HelloController, :world, :api
-          get "/hello", HelloController, :world, :api
-          get "/hello/:role", HelloController, :world, :api
+        routes :api do
+          get "/", HelloController, :world
+          get "/hello", HelloController, :world
+          get "/hello/:role", HelloController, :world
         end
       end
     end

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -61,8 +61,8 @@ module Amber
       with self yield self
     end
 
-    macro routes
-      router.draw do
+    macro routes(valve, scope = "")
+      router.draw {{valve}}, {{scope}} do
         {{yield}}
       end
     end

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -5,12 +5,12 @@ module Amber::DSL
     end
   end
 
-  record Router, router : Pipe::Router do
-    macro route(verb, resource, controller, action, pipeline)
+  record Router, router : Pipe::Router, valve : Symbol, scope : String do
+    macro route(verb, resource, controller, action)
       %controller = {{controller.id}}.new
       %handler = ->%controller.{{action.id}}
       %verb = {{verb.upcase.id.stringify}}
-      %route = Amber::Route.new(%verb, {{resource}}, %controller, %handler, {{action}}, {{pipeline}})
+      %route = Amber::Route.new(%verb, {{resource}}, %controller, %handler, {{action}}, valve, scope)
 
       router.add(%route)
     end

--- a/src/amber/router/pipe/router.cr
+++ b/src/amber/router/pipe/router.cr
@@ -24,13 +24,17 @@ module Amber
       end
 
       # This registers all the routes for the application
-      def draw
-        with DSL::Router.new(self) yield
+      def draw(valve : Symbol)
+        with DSL::Router.new(self, valve, "") yield
+      end
+
+      def draw(valve : Symbol, scope : String)
+        with DSL::Router.new(self, valve, scope) yield
       end
 
       def add(route : Route)
         trail = build_node(route.verb, route.resource)
-        node = @routes.add(trail, route)
+        node = @routes.add(route.trail, route)
         add_head(route) if route.verb == :GET
         node
       rescue Radix::Tree::DuplicateError
@@ -58,8 +62,7 @@ module Amber
       end
 
       private def add_head(route)
-        trail = build_node(:HEAD, route.resource)
-        @routes.add(trail, route)
+        @routes.add(route.trail_head, route)
       end
     end
   end

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -1,13 +1,22 @@
 module Amber
   class Route
-    property :controller, :handler, :action, :verb, :resource, :valve, :params
+    property :controller, :handler, :action, :verb, :resource, :valve, :params,:scope
 
     def initialize(@verb : String,
                    @resource : String,
                    @controller = Controller::Base.new,
                    @handler : Proc(String) = ->{ "500" },
                    @action : Symbol = :index,
-                   @valve : Symbol = :web)
+                   @valve : Symbol = :web,
+                   @scope : String = "")
+    end
+
+    def trail
+      "#{verb.to_s.downcase}#{scope}#{resource}"
+    end
+
+    def trail_head
+      "head#{scope}#{resource}"
     end
 
     def call(context)


### PR DESCRIPTION
## Routing Scope and Through parameters to routes.

Issue: [Routing Scopes [ch40]](https://app.clubhouse.io/amber/story/40/route-scopes)

### Requirements

Scopes are a way to group routes under a common path prefix and scoped
set of plug middleware. We might want to do this for admin
functionality, APIs, and especially for versioned APIs. Let's say we
have user generated reviews on a site, and that those reviews first need
to be approved by an admin. The semantics of these resources are quite
different, and they might not share the same controller. Scopes enable
us to segregate these routes.

### Description of the Change

Overloaded the router.draw method to receive a valve and through
attributes. With these 2 attributes routes can now be defined as follow.

```crystal 
routes :web, "/v2" do
    get "/hello", HelloController, :index
    get "/hello/:planet", HelloController, :world
    get "/hello/template", HelloController, :template
end
```


### Why Should This Be In Core?

- This allows defining scopes for routes which are important for APIs versioning
- Allows for a cleaner definition for routes.

### Benefits

- No longer have to append the pipeline at the end of the route definition. `get "/hello", HelloController, :index, :web`
- When serving static files the scope follows a folder path for instance 
