### PR TITLE
fixed routing helper resources

### DIFF
--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -21,7 +21,6 @@ module Amber::DSL
     end
 
     {% for verb in RESOURCES %}
-
       macro {{verb.id}}(*args)
         route {{verb}}, \{{*args}}
       end
@@ -29,15 +28,30 @@ module Amber::DSL
     {% end %}
 
     # TODO Clean this up
-    macro resources(path, controller, actions = [:index, :edit, :new, :show, :create, :update, :put, :delete])
-      get "{{path.id}}", {{controller}}, :index if {{actions}}.includes?(:index)
-      get "{{path.id}}/:id/edit", {{controller}}, :edit  if {{actions}}.includes?(:edit)
-      get "{{path.id}}/new", {{controller}}, :new if {{actions}}.includes?(:new)
-      get "{{path.id}}/:id", {{controller}}, :show if {{actions}}.includes?(:show)
-      post "{{path.id}}", {{controller}}, :create if {{actions}}.includes?(:create)
-      patch "{{path.id}}/:id", {{controller}}, :update if {{actions}}.includes?(:update)
-      put "{{path.id}}/:id", {{controller}}, :update if {{actions}}.includes?(:update)
-      delete "{{path.id}}/:id", {{controller}}, :delete if {{actions}}.includes?(:delete)
+    macro resources(path, controller, actions = [:index, :edit, :new, :show, :create, :update, :delete])
+      {% if actions.includes?(:index) %}
+      get "{{path.id}}", {{controller}}, :index
+      {% end %}
+      {% if actions.includes?(:edit) %}
+      get "{{path.id}}/:id/edit", {{controller}}, :edit
+      {% end %}
+      {% if actions.includes?(:new) %}
+      get "{{path.id}}/new", {{controller}}, :new
+      {% end %}
+      {% if actions.includes?(:show) %}
+      get "{{path.id}}/:id", {{controller}}, :show
+      {% end %}
+      {% if actions.includes?(:create) %}
+      post "{{path.id}}", {{controller}}, :create
+      {% end %}
+      {% if actions.includes?(:update) %}
+      patch "{{path.id}}/:id", {{controller}}, :update
+      put "{{path.id}}/:id", {{controller}}, :update
+      {% end %}
+      {% if actions.includes?(:delete) %}
+      delete "{{path.id}}/:id", {{controller}}, :delete
+      {% end %}
     end
+    
   end
 end


### PR DESCRIPTION
### Description of the Change
If I create resourceful routes like:
```cr
resources "posts", PostController, [:index, :show]
```

It errors on compile because all the other actions don't exist in my controller. This happens because the if in the following code happens at run time but the macro that creates the route happens at compile time. 

```cr
    macro resources(path, controller, actions = [:index, :edit, :new, :show, :create, :update, :put, :delete])
      get "{{path.id}}", {{controller}}, :index if {{actions}}.includes?(:index)
      get "{{path.id}}/:id/edit", {{controller}}, :edit  if {{actions}}.includes?(:edit)
      get "{{path.id}}/new", {{controller}}, :new if {{actions}}.includes?(:new)
      get "{{path.id}}/:id", {{controller}}, :show if {{actions}}.includes?(:show)
      post "{{path.id}}", {{controller}}, :create if {{actions}}.includes?(:create)
      patch "{{path.id}}/:id", {{controller}}, :update if {{actions}}.includes?(:update)
      put "{{path.id}}/:id", {{controller}}, :update if {{actions}}.includes?(:update)
      delete "{{path.id}}/:id", {{controller}}, :delete if {{actions}}.includes?(:delete)
    end
```

The fix is to check if actions include the right thing at compile time in the macro before creating the route. Like this:
```cr
{% if actions.includes?(:index) %}
get "{{path.id}}", {{controller}}, :index
{% end %}
```

### Why Should This Be In Core?

Because route helpers are useful.

### Benefits

It works now for more cases.

### Applicable Issues

https://github.com/Amber-Crystal/amber/issues/39
