### PR TITLE
Controllers actions are expected to return a String not an Int32.

### DIFF
--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -11,6 +11,7 @@ module Amber::Controller
     def redirect_to(location : String | Symbol, status = 302)
       response.headers.add "Location", parse_redirect(location)
       response.status_code = status
+      "redirecting..."
     end
 
     private def parse_redirect(location)


### PR DESCRIPTION
### Description of the Change

The `redirect_to` method is currently returning an Int32 of 302 instead of a string. This breaks actions that use a redirect.

### Alternate Designs

An action could be allowed to return a Union(String | Int32) but there is not benefit to returning an Int32.

### Why Should This Be In Core?

It's a bug fix for something already in the core.
