### PR TITLE
Better Redirect module for controller

### DIFF
--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -4,7 +4,7 @@ require "./*"
 module Amber::Controller
   class Base
     include Render
-    include Redirect
+    include RedirectFactory
     include Callbacks
 
     protected getter request : HTTP::Request

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -1,40 +1,58 @@
 module Amber::Controller
-  module Redirect
-    # Supports redirection in the following signatures
-    #
-    # reditect_to location, status
-    # redirect_to "/new"
-    # redirect_to "/home/index"
-    # redirect_to :back
-    # redirect_to :show
-    # redirect_to "http://www.ambercr.io"
-    def redirect_to(location : String | Symbol, status = 302)
-      response.headers.add "Location", parse_redirect(location)
-      response.status_code = status
-      "redirecting..."
+  # This class writes the redirect URL to the response headers and parses params.
+  class LocationRedirect
+    getter location, status, flash, query_params
+
+    def initialize(@location : String,
+                   @status = 302,
+                   @query_params : Hash(String, String)? = nil)
+      # Todo add flash as a parameter for redirect
+      # Todo add default route scope for given controller action
+      raise_redirect_error(location) if location.empty?
     end
 
-    private def parse_redirect(location)
-      return string_location(location) if location.is_a? String
-      return back() if location == :back
-      return "/#{location}" if location.is_a? Symbol
+    def redirect(for response)
+      return set_location(response, location, status, query_params) if location.url?
+      return set_location(response, location, status, query_params) if location.chars.first == '/'
+      raise_redirect_error(location)
+    end
+
+    private def set_location(response, location, status = 302, query_params : _ = nil)
+      url_path = encode_query_string(location, query_params)
+      response.headers.add "Location", url_path
+      response.status_code = status
+
+      "Redirecting to #{url_path}"
+    end
+
+    def encode_query_string(location, query_params)
+      return location + "?" + HTTP::Params.encode(query_params).to_s if query_params
       location
     end
 
-    private def string_location(location)
-      return location if location.url?
-      return location if location.chars[0] != "/"
-      raise_error(location)
-    end
-
-    private def back
-      referer = request.headers["Referer"]?
-      return referer if !referer.nil? && !referer.empty?
-      raise Exceptions::Controller::Redirect.new(:back)
-    end
-
-    private def raise_error(location)
+    def raise_redirect_error(location)
       raise Exceptions::Controller::Redirect.new(location)
+    end
+  end
+
+  module RedirectFactory
+    def redirect_to(location : String, *args)
+      LocationRedirect.new(location, *args).redirect(response)
+    end
+
+    # Redirects to the specified controller, action
+    def redirect_to(controller : Symbol, action : Symbol, *args)
+      LocationRedirect.new("/#{controller}/#{action}", *args).redirect(response)
+    end
+
+    # Redirects within the same controller
+    def redirect_to(action : Symbol, *args)
+      controller = self.class.to_s.chomp("Controller").downcase
+      LocationRedirect.new("/#{controller}/#{action}", *args).redirect(response)
+    end
+
+    def redirect_back(*args)
+      LocationRedirect.new(request.headers["Referer"]).redirect(response)
     end
   end
 end


### PR DESCRIPTION
### Requirements

This PR makes better use of redirect_to controller method by allowing to define fallback for redirect_back, define controller and action. 

### Description of the Change

When using redirect_back(fallback), if there is no referrer, a redirect error will be raised. You may specify some fallback target define below.

Redirects the browser to the target specified

**Targets:**

* Location this can be a path string, domain name, link.
* Controller and Action this is the target controller and the target action within the controller
* Action the target action of the current controller.

