### PR TITLE
removed :id from resourceful route `new`

### DIFF
--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -50,7 +50,7 @@ module Amber::DSL
       {% elsif action == :show %}
         get "{{path.id}}/:id", {{controller}}, :show
       {% elsif action == :new %}
-        get "{{path.id}}/:id/new", {{controller}}, :new
+        get "{{path.id}}/new", {{controller}}, :new
       {% elsif action == :edit %}
         get "{{path.id}}/:id/edit", {{controller}}, :edit
       {% elsif action == :create %}


### PR DESCRIPTION
### Description of the Change
Changed resource route `new` from `routes/:id/new` to `routes/new'.

### Why Should This Be In Core?

It's a bug fix.

### Benefits

All resourceful routes will work again.
