### PR TITLE
Removes id from new resources

### DIFF
--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -13,7 +13,7 @@ module Amber
 
           router.match("GET", "/hello").key.should eq "get/hello"
           router.match("GET", "/hello/2").key.should eq "get/hello/:id"
-          router.match("GET", "/hello/2/new").key.should eq "get/hello/:id/new"
+          router.match("GET", "/hello/new").key.should eq "get/hello/new"
           router.match("GET", "/hello/2/edit").key.should eq "get/hello/:id/edit"
           router.match("PUT", "/hello/1").key.should eq "get/helloput/hello/:id"
           router.match("PATCH", "/hello/1").key.should eq "get/hellopatch/hello/:id"
@@ -31,7 +31,7 @@ module Amber
 
             router.match("GET", "/hello").key.should eq "get/hello"
             router.match("GET", "/hello/2").key.should eq ""
-            router.match("GET", "/hello/2/new").key.should eq ""
+            router.match("GET", "/hello/new").key.should eq ""
             router.match("GET", "/hello/2/edit").key.should eq ""
             router.match("PUT", "/hello/1").key.should eq "get/helloput/hello/:id"
             router.match("PATCH", "/hello/1").key.should eq "get/hellopatch/hello/:id"
@@ -45,13 +45,13 @@ module Amber
               resources "/hello", HelloController, except: [:index, :update]
             end
 
-            router.match("GET", "/hello").key.should eq ""
+            router.match("GET", "/hello").key.should eq "get/hello/"
             router.match("GET", "/hello/2").key.should eq "get/hello/:id"
-            router.match("GET", "/hello/2/new").key.should eq "get/hello/:id/new"
+            router.match("GET", "/hello/new").key.should eq "get/hello/new"
             router.match("GET", "/hello/2/edit").key.should eq "get/hello/:id/edit"
-            router.match("PUT", "/hello/1").key.should eq ""
-            router.match("PATCH", "/hello/1").key.should eq ""
-            router.match("DELETE", "/hello/1").key.should eq "get/hello/:iddelete/hello/:id"
+            router.match("PUT", "/hello/1").key.should eq "get/hello/:id"
+            router.match("PATCH", "/hello/1").key.should eq "get/hello/:id"
+            router.match("DELETE", "/hello/1").key.should eq "get/hello/delete/hello/:id"
           end
         end
       end

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -50,7 +50,7 @@ module Amber::DSL
       {% elsif action == :show %}
         get "{{path.id}}/:id", {{controller}}, :show
       {% elsif action == :new %}
-        get "{{path.id}}/:id/new", {{controller}}, :new
+        get "{{path.id}}/new", {{controller}}, :new
       {% elsif action == :edit %}
         get "{{path.id}}/:id/edit", {{controller}}, :edit
       {% elsif action == :create %}


### PR DESCRIPTION
Resources new should not make use of the :id in the
path.

Remove :id from resource and updated specs

After this changes the new resource should not required the :id in the
url path.
