### PR TITLE
websockets infrastructure

### DIFF
--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -1,0 +1,5 @@
+import { Socket } from './websockets/socket'
+
+export default {
+  Socket: Socket
+}

--- a/assets/js/websockets/channel.js
+++ b/assets/js/websockets/channel.js
@@ -1,0 +1,35 @@
+const EVENTS = {
+  join: 'join',
+  leave: 'leave',
+  message: 'message'
+}
+
+export class Channel {
+  constructor (topic, socket) {
+    this.topic = topic
+    this.socket = socket
+    this.onMessageHandlers = []
+  }
+
+  join () {
+    this.socket.ws.send(JSON.stringify({event: EVENTS.join, topic: this.topic}))
+  }
+
+  leave () {
+    this.socket.ws.send(JSON.stringify({event: EVENTS.message, topic: this.topic}))
+  }
+
+  handleMessage (msg) {
+    this.onMessageHandlers.forEach((handler) => {
+      if (handler.subject === msg.subject) handler.callback(msg.payload)
+    })
+  }
+
+  on (subject, callback) {
+    this.onMessageHandlers.push({subject: subject, callback: callback})
+  }
+
+  push (subject, payload) {
+    this.socket.ws.send(JSON.stringify({event: EVENTS.message, topic: this.topic, subject: subject, payload: payload}))
+  }
+}

--- a/assets/js/websockets/socket.js
+++ b/assets/js/websockets/socket.js
@@ -1,0 +1,27 @@
+import { Channel } from './channel'
+
+export class Socket {
+  constructor (endpoint) {
+    this.endpoint = endpoint
+    this.ws = null
+    this.channels = []
+  }
+
+  connect (params) {
+    this.ws = new WebSocket(`ws://localhost:8080${this.endpoint}`)
+    this.ws.onmessage = (msg) => { this.handleMessage(msg) }
+  }
+
+  channel (topic) {
+    let channel = new Channel(topic, this)
+    this.channels.push(channel)
+    return channel
+  }
+
+  handleMessage (msg) {
+    msg = JSON.parse(msg.data)
+    this.channels.forEach((channel) => {
+      if (channel.topic === msg.topic) channel.handleMessage(msg)
+    })
+  }
+}

--- a/spec/amber/websockets/client_socket_spec.cr
+++ b/spec/amber/websockets/client_socket_spec.cr
@@ -1,0 +1,56 @@
+require "../../../spec_helper"
+
+module Amber
+  describe WebSockets::ClientSocket do
+    describe "#channel" do
+      it "should add channels" do
+        UserSocket.channels[0][:path].should eq "user_room:*"
+        UserSocket.channels[0][:channel].should be_a UserChannel
+      end
+    end
+
+    describe "#initialize" do
+      it "should set the socket and socket id" do
+        ws, client_socket = create_user_socket
+
+        client_socket.socket.should eq ws
+        client_socket.id.should eq ws.object_id
+      end
+    end
+
+    describe "#on_connect" do
+      it "should default to true" do
+        ws, client_socket = create_user_socket
+        client_socket.on_connect.should be_true
+      end
+    end
+
+    describe "#authorized?" do
+      it "should equal on_connect" do
+        ws, client_socket = create_user_socket
+        client_socket.authorized?.should eq client_socket.on_connect
+      end
+    end
+
+    describe "#on_message" do
+      describe "join event" do
+        it "should add a subscription" do
+          ws, client_socket = create_user_socket
+          client_socket.subscribed_to_topic?("user_room:123").should be_false
+          client_socket.on_message({event: "join", topic: "user_room:123"}.to_json)
+          client_socket.subscribed_to_topic?("user_room:123").should be_true
+        end
+      end
+
+      describe "leave event" do
+        it "should remove the subscription" do
+          ws, client_socket = create_user_socket
+          client_socket.on_message({event: "join", topic: "user_room:123"}.to_json)
+          client_socket.subscribed_to_topic?("user_room:123").should be_true
+          client_socket.on_message({event: "leave", topic: "user_room:123"}.to_json)
+          client_socket.subscribed_to_topic?("user_room:123").should be_false
+        end
+      end
+    end
+  end
+end

--- a/spec/amber/websockets/client_sockets_spec.cr
+++ b/spec/amber/websockets/client_sockets_spec.cr
@@ -1,0 +1,36 @@
+require "../../../spec_helper"
+
+module Amber
+  describe WebSockets::ClientSockets do
+    describe "#add_client_socket" do
+      it "should add the client socket to the list" do
+        ws, client_socket = create_user_socket
+        WebSockets::ClientSockets.add_client_socket(client_socket)
+
+        WebSockets::ClientSockets.client_sockets[client_socket.id].should eq client_socket
+      end
+    end
+
+    describe "#remove_client_socket do" do
+      it "should remove the client socket from the list" do
+        ws, client_socket = create_user_socket
+        WebSockets::ClientSockets.add_client_socket(client_socket)
+        WebSockets::ClientSockets.remove_client_socket(client_socket)
+
+        WebSockets::ClientSockets.client_sockets[client_socket.id]?.should be_nil
+      end
+    end
+
+    describe "#get_subscribers_for_topic" do
+      it "should return all of the subscribers for the topic" do
+        ws, client_socket1 = create_user_socket
+        ws, client_socket2 = create_user_socket
+        WebSockets::ClientSockets.add_client_socket(client_socket1)
+        WebSockets::ClientSockets.add_client_socket(client_socket2)
+        client_socket1.on_message({event: "join", topic: "user_room:123"}.to_json)
+        client_socket2.on_message({event: "join", topic: "user_room:123"}.to_json)
+        WebSockets::ClientSockets.get_subscribers_for_topic("user_room:123").values.should eq [client_socket1, client_socket2]
+      end
+    end
+  end
+end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -72,3 +72,13 @@ class TestController < Amber::Controller::Base
     render("test.slang", "layout.slang", "spec/sample/views", "./")
   end
 end
+
+struct UserSocket < Amber::WebSockets::ClientSocket
+  channel "user_room:*", UserChannel
+end
+
+class UserChannel < Amber::WebSockets::Channel
+  def handle_joined; end
+
+  def handle_message(msg); end
+end

--- a/spec/support/helpers.cr
+++ b/spec/support/helpers.cr
@@ -32,3 +32,9 @@ def build_controller(referer)
   hello_controller = HelloController.new(context)
   hello_controller
 end
+
+def create_user_socket
+  ws = HTTP::WebSocket.new(STDOUT)
+  client_socket = UserSocket.new(ws)
+  return ws, client_socket
+end

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -59,6 +59,10 @@ module Amber
       with self yield self
     end
 
+    def socket_endpoint(path, app_socket)
+      WebSockets::Server.create_endpoint(path, app_socket)
+    end
+
     macro routes(valve, scope = "")
       router.draw {{valve}}, {{scope}} do
         {{yield}}

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -1,0 +1,26 @@
+module Amber
+  module WebSockets
+    # Sockets subscribe to Channel's, where the communication log is handled.  The channel provides funcionality
+    # to handle socket join `handle_joined` and socket messages `handle_message(msg)`.
+    abstract class Channel
+      def initialize; end
+
+      abstract def handle_joined
+      abstract def handle_message(msg)
+
+      protected def subscribe_to_channel
+        handle_joined
+      end
+
+      protected def dispatch(msg)
+        handle_message(msg)
+      end
+
+      # Rebroadcast this message to all subscribers of the channel
+      protected def rebroadcast!(msg)
+        subscribers = ClientSockets.get_subscribers_for_topic(msg["topic"])
+        subscribers.each_value(&.socket.send(msg.to_json))
+      end
+    end
+  end
+end

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -1,0 +1,80 @@
+module Amber
+  module WebSockets
+    # `ClientSocket` struct maps a user to an [HTTP::WebSocket](https://crystal-lang.org/api/0.22.0/HTTP/WebSocket.html).  For every websocket connection
+    # there will be an associated ClientSocket.  Authentication and authorization happen within the `ClientSocket`.  `ClientSocket` will subscribe to `Channel`s,
+    # where incoming and outgoing messages are routed through.
+    #
+    # Example:
+    #
+    # ```crystal
+    # struct UserSocket < Amber::Websockets::ClientSocket
+    #   channel "user_channel/*", UserChannel
+    #   channel "room_channel/*", RoomChannel
+    #
+    #   def on_connect
+    #     return some_auth_method!
+    #   end
+    # end
+    # ```
+    abstract struct ClientSocket
+      @@channels = [] of NamedTuple(path: String, channel: Channel)
+
+      property id : UInt64
+      property socket : HTTP::WebSocket
+
+      # Add a channel for this socket to listen, publish to
+      def self.channel(channel_path, ch)
+        @@channels.push({path: channel_path, channel: ch.new})
+      end
+
+      def self.channels
+        @@channels
+      end
+
+      def self.get_topic_channel(topic)
+        topic_channels = @@channels.select { |ch| ch[:path].split(":")[0] == topic }
+        return topic_channels[0][:channel] if topic_channels.any?
+      end
+
+      def initialize(@socket)
+        @id = @socket.object_id
+        @subscription_manager = SubscriptionManager.new
+        @socket.on_pong do |msg|
+          # TODO: setup heartbeat
+        end
+        self.on_connect
+      end
+
+      # Authentication and authorization shuould happen here
+      def on_connect : Bool
+        true
+      end
+
+      # Sends ping opcode to client : https://tools.ietf.org/html/rfc6455#section-5.5.2
+      def beat
+        spawn { @socket.ping }
+      end
+
+      def subscribed_to_topic?(topic)
+        @subscription_manager.subscriptions.keys.includes?(topic.to_s)
+      end
+
+      protected def authorized?
+        on_connect
+      end
+
+      protected def on_message(message)
+        if @socket.closed?
+          Amber::Server.instance.log.error "Ignoring message sent to closed socket"
+        else
+          @subscription_manager.dispatch self, decode(message)
+        end
+      end
+
+      protected def decode(message)
+        # TODO: implement different decoders
+        JSON.parse(message)
+      end
+    end
+  end
+end

--- a/src/amber/websockets/client_sockets.cr
+++ b/src/amber/websockets/client_sockets.cr
@@ -1,0 +1,46 @@
+module Amber
+  module WebSockets
+    #
+    # Manages the entire collection of ClientSocket's.  Manages periodic timers for socket connections (heartbeat).
+    #
+    module ClientSockets
+      extend self
+      @@client_sockets = Hash(UInt64, ClientSocket).new
+      @@heartbeat_started = false
+      BEAT_INTERVAL = 3.seconds
+
+      def add_client_socket(client_socket)
+        @@client_sockets[client_socket.id] = client_socket
+      end
+
+      def remove_client_socket(client_socket)
+        @@client_sockets.delete(client_socket.id)
+      end
+
+      def client_sockets
+        @@client_sockets
+      end
+
+      # Implement ping / pong control frames, to prevent stale connections : https://tools.ietf.org/html/rfc6455#section-5.5.2
+      def setup_heartbeat
+        return if @@heartbeat_started
+        heartbeat
+      end
+
+      def get_subscribers_for_topic(topic)
+        @@client_sockets.select do |k, client_socket|
+          client_socket.subscribed_to_topic?(topic.to_s)
+        end
+      end
+
+      private def heartbeat
+        spawn do
+          @@heartbeat_started = true
+          @@client_sockets.each_value(&.beat)
+          sleep BEAT_INTERVAL
+          heartbeat
+        end
+      end
+    end
+  end
+end

--- a/src/amber/websockets/server.cr
+++ b/src/amber/websockets/server.cr
@@ -1,0 +1,39 @@
+module Amber
+  module WebSockets
+    module Server
+      extend self
+
+      def create_endpoint(path, app_socket)
+        spawn do
+          Amber::Server.instance.log.info "socket listening at #{path}"
+          Handler.new(path) do |socket|
+            instance = app_socket.new(socket)
+            socket.close && next unless instance.authorized?
+
+            ClientSockets.add_client_socket(instance)
+
+            socket.on_message do |message|
+              instance.on_message(message)
+            end
+
+            socket.on_close do
+              ClientSockets.remove_client_socket(instance)
+            end
+          end
+
+          ClientSockets.setup_heartbeat
+        end
+      end
+
+      class Handler < HTTP::WebSocketHandler
+        def initialize(@path : String, &@proc : HTTP::WebSocket, HTTP::Server::Context -> Void)
+          Router::Router.instance.add_socket_route(@path, self)
+        end
+
+        def call(context)
+          super
+        end
+      end
+    end
+  end
+end

--- a/src/amber/websockets/subscription_manager.cr
+++ b/src/amber/websockets/subscription_manager.cr
@@ -1,0 +1,43 @@
+module Amber
+  module WebSockets
+    # `SubscriptionManager` manages the list of channel subscriptions for the socket connection.
+    # Also handles dispatching actions (messages) to the appropriate channel.
+    struct SubscriptionManager
+      property subscriptions = Hash(String, Channel).new
+
+      def dispatch(client_socket, message)
+        event = message["event"]?
+        return unless event
+
+        case event
+        when "join"    then join client_socket, message
+        when "message" then message client_socket, message
+        when "leave"   then unsubscribe client_socket, message
+        else
+          Amber::Server.instance.log.error "Uncaptured event #{event}"
+        end
+      end
+
+      def join(client_socket, message)
+        return if subscriptions[message["topic"]]?
+        topic = message["topic"].as_s.split(":")[0]
+        if channel = client_socket.class.get_topic_channel(topic)
+          channel.subscribe_to_channel
+          subscriptions[message["topic"].as_s] = channel
+        end
+      end
+
+      def message(client_socket, message)
+        if channel = subscriptions[message["topic"].as_s]?
+          channel.dispatch(message)
+        end
+      end
+
+      def unsubscribe(client_socket, message)
+        if channel = subscriptions[message["topic"].as_s]?
+          subscriptions.delete(message["topic"].as_s)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Requirements

Initial implementation of a websocket handler, manager and server.  

### Description of the Change

This PR allows for a websocket handler to be created within the application config block.  A user can also define their own `Socket` and `Channel` functionality (authentication, message handling, etc).  Example code below.

### Why Should This Be In Core?

* Allows for websocket communication to be easily added to any application.

### Features still TODO

* Heartbeat - server: to kill dead connections, client: to ensure connection to server is still active
* PubSub implementation through redis / postgres - for application scalability
* Allow for different decoding methods - allow the user to use something other that JSON if they want.
* rebroadcast join and leave automatically (see how other frameworks do this)?
* Message buffering?
* Long polling fallback?

### Example Code

1. Create a socket and channel:
```crystal
struct UserSocket < Amber::WebSockets::ClientSocket
  channel "chat_room:*", ChatChannel

  def on_connect
    # This runs when the socket connects.  Authentication should happen here.
    # If `on_connect` returns false, the socket will be closed.
    true
  end
end

class ChatChannel < Amber::WebSockets::Channel
  def handle_joined
    # Called when a user joins a channel
  end

  def handle_message(msg)
    # Called when a message is sent to the channel
    # use rebroadcast! to broadcast to the message to all users subscribed to the channel
    rebroadcast!(msg)
  end
end
```

2. In the application config block, define the handler endpoint
```crystal
MyApp.config do
  ...
  socket_endpoint "/chat", UserSocket
 ...
end
```

3. Javascript library usage:
```javascript
let socket = new Amber.Socket("/chat");
socket.connect();

let channel = socket.channel('chat_room:123')
channel.join()

channel.on('msg:new', (msg) => { console.log('new message : ', msg) } )

channel.push('msg:new', {message: 'hey guys'})
```
