### PR TITLE
Added csrf tag helper and framework for other helpers.

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -33,6 +33,26 @@ module Amber::Controller
 
         TestController.new(context).render_with_layout.should eq html_output
       end
+
+      it "renders a form with a csrf tag" do
+        request = HTTP::Request.new("GET", "/?test=test")
+        context = create_context(request)
+        html_output = <<-HTML
+        <form action="/posts" method="post">
+          <input type="hidden" name="_csrf" value="#{Amber::Pipe::CSRF.instance.token(context)}" />
+          <div class="form-group">
+            <input class="form-control" type="text" name="title" placeholder="Title" value="hey you">
+          </div>
+          <div class="form-group">
+            <textarea class="form-control" rows="10" name="content" placeholder="Content">out there in the cold</textarea>
+          </div>
+          <button class="btn btn-primary btn-xs" type="submit">Submit</button>
+          <a class="btn btn-default btn-xs" href="/posts">back</a>
+        </form>
+        HTML
+
+        TestController.new(context).render_with_csrf.should eq html_output
+      end
     end
 
     describe "#before_action" do

--- a/spec/sample/views/test/_form.slang
+++ b/spec/sample/views/test/_form.slang
@@ -1,0 +1,8 @@
+form action="/posts" method="post"
+  == csrf_tag
+  div.form-group
+    input.form-control type="text" name="title" placeholder="Title" value="hey you"
+  div.form-group
+    textarea.form-control rows="10" name="content" placeholder="Content" = "out there in the cold" 
+  button.btn.btn-primary.btn-xs type="submit" Submit
+  a.btn.btn-default.btn-xs href="/posts" back

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -71,6 +71,10 @@ class TestController < Amber::Controller::Base
   def render_with_layout
     render("test/test.slang", "layout.slang", "spec/sample/views", "./")
   end
+
+  def render_with_csrf
+    render("spec/sample/views/test/_form.slang", layout: false)
+  end
 end
 
 struct UserSocket < Amber::WebSockets::ClientSocket

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -1,11 +1,12 @@
 require "http"
-require "./*"
+require "./**"
 
 module Amber::Controller
   class Base
     include Render
     include RedirectFactory
     include Callbacks
+    include Helpers::Tag
 
     protected getter request : HTTP::Request
     protected getter response : HTTP::Server::Response

--- a/src/amber/controller/helpers/tags.cr
+++ b/src/amber/controller/helpers/tags.cr
@@ -1,0 +1,7 @@
+module Amber::Controller::Helpers
+  module Tag
+    def csrf_tag
+      Amber::Pipe::CSRF.instance.tag(context)
+    end
+  end
+end


### PR DESCRIPTION
### Description of the Change

Added a `helpers` folder at `src/amber/controller/helpers/`. Added `tag.cr` which currently only contains the `csrf_tag` helper.

### Why Should This Be In Core?

Csrf pipe is part of the core and this makes it easier for the end user to use it.

