### PR TITLE
Don't start a new process if thread_count is one.

### DIFF
--- a/src/amber.cr
+++ b/src/amber.cr
@@ -40,7 +40,7 @@ module Amber
     def run
       ENV["THREAD_COUNT"] ||= "1"
       thread_count = ENV["THREAD_COUNT"].to_i
-      if Cluster.master?
+      if Cluster.master? && thread_count > 1
         while(thread_count > 0)
           Cluster.fork ({"id" => thread_count.to_s})
           thread_count -= 1


### PR DESCRIPTION
### Description of the Change

Stop fun from creating a new process when thread count is 1. This saves a tiny bit of time and makes processes easier to handle so that `amber watch` still works.

### Benefits

Amber watch works. Doesn't spawn unnecessary thread.
