### PR TITLE
Removes Singeleton Pattern from Handlers

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -39,7 +39,7 @@ module Amber::Controller
         context = create_context(request)
         html_output = <<-HTML
         <form action="/posts" method="post">
-          <input type="hidden" name="_csrf" value="#{Amber::Pipe::CSRF.instance.token(context)}" />
+          <input type="hidden" name="_csrf" value="#{Amber::Pipe::CSRF.new.token(context)}" />
           <div class="form-group">
             <input class="form-control" type="text" name="title" placeholder="Title" value="hey you">
           </div>

--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -6,7 +6,7 @@ module Amber
       context "when requests have HTTP methods" do
         CSRF::CHECK_METHODS.each do |method|
           it "raises forbbiden error for PUT request" do
-            csrf = CSRF.instance
+            csrf = CSRF.new
             request = HTTP::Request.new(method, "/")
           expect_raises Exceptions::Forbidden do
             make_router_call(csrf, request)
@@ -18,7 +18,7 @@ module Amber
       context "when requests have allowed HTTP methods" do
         %w(GET HEAD OPTIONS TRACE CONNECT).each do |method|
           it "accepts requests for GET methods" do
-            csrf = CSRF.instance
+            csrf = CSRF.new
             request = HTTP::Request.new(method, "/")
 
             response = make_router_call(csrf, request)
@@ -30,7 +30,7 @@ module Amber
 
       context "when tokens match" do
         it "accepts requests params token" do
-          csrf = CSRF.instance
+          csrf = CSRF.new
           valid_token = "good_token"
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
@@ -44,7 +44,7 @@ module Amber
         end
 
         it "accepts requests for header token" do
-          csrf = CSRF.instance
+          csrf = CSRF.new
           valid_token = "good_token"
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
@@ -60,7 +60,7 @@ module Amber
 
       context "when tokens don't match" do
         it "raises a forbbiden error for params token" do
-          csrf = CSRF.instance
+          csrf = CSRF.new
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
 
@@ -73,7 +73,7 @@ module Amber
         end
 
         it "raises a forbbiden error for header token" do
-          csrf = CSRF.instance
+          csrf = CSRF.new
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
 

--- a/spec/amber/router/pipe/error_spec.cr
+++ b/spec/amber/router/pipe/error_spec.cr
@@ -4,7 +4,7 @@ module Amber
   module Pipe
     describe Error do
       it "returns status code 404 when route not found" do
-        router = Error.instance
+        router = Error.new
         request = HTTP::Request.new("GET", "/")
 
         response = create_request_and_return_io(router, request)
@@ -13,7 +13,7 @@ module Amber
       end
 
       it "returns status code 500 for all other exceptions" do
-        error = Error.instance
+        error = Error.new
         request = HTTP::Request.new("GET", "/")
         error.next = ->(context : HTTP::Server::Context) { raise "Oops!" }
 

--- a/spec/amber/router/pipe/flash_spec.cr
+++ b/spec/amber/router/pipe/flash_spec.cr
@@ -4,7 +4,7 @@ module Amber
   module Pipe
     describe Flash do
       it "sets a cookie" do
-        flash = Flash.instance
+        flash = Flash.new
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
 
@@ -14,7 +14,7 @@ module Amber
       end
 
       it "sets a flash message" do
-        flash = Flash.instance
+        flash = Flash.new
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
         context.flash["error"] = "There was a problem"
@@ -25,7 +25,7 @@ module Amber
       end
 
       it "returns a list of flash messages that have not been read" do
-        flash = Flash.instance
+        flash = Flash.new
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
         context.flash["error"] = "There was a problem"
@@ -36,7 +36,7 @@ module Amber
       end
 
       it "does not return read messages" do
-        flash = Flash.instance
+        flash = Flash.new
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
         context.flash["error"] = "There was a problem"
@@ -47,7 +47,7 @@ module Amber
       end
 
       it "supports enumerable" do
-        flash = Flash.instance
+        flash = Flash.new
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
         context.flash["error"] = "There was a problem"

--- a/spec/amber/router/pipe/session_spec.cr
+++ b/spec/amber/router/pipe/session_spec.cr
@@ -6,31 +6,36 @@ module Amber
       it "sets a cookie" do
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
-        session = Session.instance
+        session = Session.new
+
         session.call(context)
+
         context.response.headers.has_key?("set-cookie").should be_true
       end
 
       it "encodes the session data" do
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
-        session = Session.instance
-        session.secret = "some-secret-key"
+        session = Session.new("key.session", "some-secret-key")
         context.session["authorized"] = "true"
+
         session.call(context)
         cookie = context.response.headers["set-cookie"]
-        cookie.should eq "#{Amber::Server.settings.project_name}.session=404f0c34f1efcb0d96e0c801fbc0fed13db667b0--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
+
+        cookie.should eq "key.session=404f0c34f1efcb0d96e0c801fbc0fed13db667b0--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
       end
 
       it "uses a secret" do
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
-        session = Session.instance
-        session.secret = "some-secret-key"
+        session = Session.new("key.session", "some-secret-key")
+        session.secret =
         context.session["authorized"] = "true"
+
         session.call(context)
         cookie = context.response.headers["set-cookie"]
-        cookie.should eq "#{Amber::Server.settings.project_name}.session=404f0c34f1efcb0d96e0c801fbc0fed13db667b0--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
+
+        cookie.should eq "key.session=67b626dc85fd1e1b9c91c3f459bdfcf0902051de--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
       end
     end
   end

--- a/spec/amber/router/pipe/static_spec.cr
+++ b/spec/amber/router/pipe/static_spec.cr
@@ -5,7 +5,7 @@ module Amber
     describe Static do
       it "renders html" do
         request = HTTP::Request.new("GET", "/index.html")
-        static = Static.instance "spec/sample/public", false
+        static = Static.new "spec/sample/public", false
 
         response = create_request_and_return_io(static, request)
 
@@ -14,7 +14,7 @@ module Amber
 
       it "returns Not Found when file doesn't exist" do
         request = HTTP::Request.new("GET", "/not_found.html")
-        static = Static.instance "spec/sample/public", false
+        static = Static.new "spec/sample/public", false
 
         response = create_request_and_return_io(static, request)
 
@@ -23,7 +23,7 @@ module Amber
 
       it "delivers index.html if path ends with /" do
         request = HTTP::Request.new("GET", "/index.html")
-        static = Static.instance "spec/sample/public", false
+        static = Static.new "spec/sample/public", false
 
         response = create_request_and_return_io(static, request)
 

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -99,7 +99,7 @@ module Amber
     end
 
     def handler
-      @handler ||= Pipe::Pipeline.instance
+      @handler ||= Pipe::Pipeline.new
     end
 
     private def router

--- a/src/amber/controller/helpers/tags.cr
+++ b/src/amber/controller/helpers/tags.cr
@@ -1,7 +1,7 @@
 module Amber::Controller::Helpers
   module Tag
     def csrf_tag
-      Amber::Pipe::CSRF.instance.tag(context)
+      Amber::Pipe::CSRF.new.tag(context)
     end
   end
 end

--- a/src/amber/router/pipe/base.cr
+++ b/src/amber/router/pipe/base.cr
@@ -2,22 +2,9 @@ require "http"
 
 module Amber
   module Pipe
-    # The base class for Amber Pipes.  This extension provides a singleton
-    # method and ability to configure each handler.  All configurations should
-    # be maintained in the `/config` folder for consistency.
+    # Base class to include the HTTP::Handler module.
     class Base
       include HTTP::Handler
-
-      # Ability to configure the singleton instance from the class
-      def self.config
-        yield self.instance
-      end
-
-      # Ability to configure the instance
-      def config
-        yield self
-      end
-
       # Execution of this handler.
       def call(context : HTTP::Server::Context)
         call_next context

--- a/src/amber/router/pipe/cors.cr
+++ b/src/amber/router/pipe/cors.cr
@@ -5,10 +5,6 @@ module Amber
       property allow_origin, allow_headers, allow_methods, allow_credentials,
         max_age
 
-      def self.instance
-        @@instance ||= new
-      end
-
       def initialize
         @allow_origin = "*"
         @allow_headers = "Accept, Content-Type"

--- a/src/amber/router/pipe/csrf.cr
+++ b/src/amber/router/pipe/csrf.cr
@@ -7,10 +7,6 @@ module Amber
       CHECK_METHODS = %w(PUT POST PATCH DELETE)
       property session_key, header_key, param_key, check_methods
 
-      def self.instance
-        @@instance ||= new
-      end
-
       def initialize
         @session_key = "csrf.token"
         @header_key = "HTTP_X_CSRF_TOKEN"

--- a/src/amber/router/pipe/error.cr
+++ b/src/amber/router/pipe/error.cr
@@ -4,10 +4,6 @@ module Amber
     # response based on the `Accepts` header as JSON or HTML.  It also catches
     # any runtime Exceptions and returns a backtrace in text/plain format.
     class Error < Base
-      # class method to return a singleton instance of this Controller
-      def self.instance
-        @@instance ||= new
-      end
 
       def call(context : HTTP::Server::Context)
         begin

--- a/src/amber/router/pipe/flash.cr
+++ b/src/amber/router/pipe/flash.cr
@@ -9,10 +9,6 @@ module Amber
     class Flash < Base
       property :key
 
-      def self.instance
-        @@instance ||= new
-      end
-
       def initialize
         @key = "amber.flash"
       end

--- a/src/amber/router/pipe/logger.cr
+++ b/src/amber/router/pipe/logger.cr
@@ -3,9 +3,6 @@ require "colorize"
 module Amber
   module Pipe
     class Logger < Base
-      def self.instance
-        @@instance ||= new
-      end
 
       def initialize(io : IO = STDOUT)
         @io = io

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -6,10 +6,6 @@ module Amber
       getter pipeline
       getter valve : Symbol
 
-      def self.instance
-        @@instance ||= new
-      end
-
       def initialize
         @valve = :web
         @pipeline = {} of Symbol => Array(HTTP::Handler)

--- a/src/amber/router/pipe/session.cr
+++ b/src/amber/router/pipe/session.cr
@@ -8,16 +8,14 @@ module Amber::Pipe
   # encode and decode the cookie and provide the hash in the context that can
   # be used to maintain data across requests.
   class Session < Base
-    property :key
     property secret : String
+    property key : String
+    property store : Symbol
 
-    def self.instance
-      @@instance ||= new
-    end
-
-    def initialize
-      @key = "#{Server.settings.project_name}.session"
-      @secret = Server.settings.secret
+    def initialize(
+      @key : String = "#{Server.settings.project_name}.session",
+      @secret : String = Server.settings.secret,
+      @store : Symbol = :cookie)
     end
 
     def call(context : HTTP::Server::Context)
@@ -36,6 +34,7 @@ module Amber::Pipe
       if sha1 == OpenSSL::HMAC.hexdigest(:sha1, @secret, data)
         values = YAML.parse(Base64.decode_string(data))
         values.each do |key, value|
+          # TODO provide a session store other than in memory
           session[key.to_s] = value.to_s
         end
       end

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -5,11 +5,6 @@ module Amber
     class Static < HTTP::StaticFileHandler
       property default_file, public_dir
 
-      # class method to return a singleton instance of this Controller
-      def self.instance(public_dir : String, fallthrough = true)
-        @@instance ||= new(public_dir, fallthrough)
-      end
-
       def initialize(public_dir : String, fallthrough = true)
         @public_dir = File.expand_path public_dir
         @fallthrough = !!fallthrough


### PR DESCRIPTION

### Description of the Change

Currently handlers are following the singleton pattern. Singleton pattern is not necessary for handlers since handlers are initialized only once per pipileline.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Benefits

- Removes uncessary code.
- Makes it easy to maintain 
- Less complexity 
- Less code.
