### PR TITLE
Fixed example site readme.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,20 @@
 ## Static Site Example
 
+Install dependencies
+
+```crystal
+shards
+
 Build the project
 
 ```crystal
-crystal build --release ./examples/demo.cr
+crystal build --release ./src/demo.cr
 ```
 Run your new Amber server
 ```crystal
-./demo.cr
+./demo
 ```
 Visit
 ```crystal
-http://localhost:4000/index.html
+http://0.0.0.0:4000/index.html
 ```


### PR DESCRIPTION
### Description of the Change
The readme for the example didn't work as written. This fixes it and adds the `shards` command to make sure shards are installed first.
