### PR TITLE
pubsub adapters

### DIFF
--- a/assets/js/websockets/socket.js
+++ b/assets/js/websockets/socket.js
@@ -8,8 +8,13 @@ export class Socket {
   }
 
   connect (params) {
-    this.ws = new WebSocket(`ws://localhost:8080${this.endpoint}`)
-    this.ws.onmessage = (msg) => { this.handleMessage(msg) }
+    return new Promise((resolve, reject) => {
+      let location = window.location.hostname
+      if (window.location.port) location += `:${window.location.port}`
+      this.ws = new WebSocket(`ws://${location}${this.endpoint}`)
+      this.ws.onmessage = (msg) => { this.handleMessage(msg) }
+      this.ws.onopen = () => resolve()
+    })
   }
 
   channel (topic) {

--- a/shard.yml
+++ b/shard.yml
@@ -22,3 +22,7 @@ dependencies:
   slang:
     github: jeromegn/slang
     branch: master
+
+  redis:
+    github: stefanwille/crystal-redis
+    version: ~> 1.8.0

--- a/spec/amber/websockets/channel_spec.cr
+++ b/spec/amber/websockets/channel_spec.cr
@@ -1,0 +1,32 @@
+require "../../../spec_helper"
+
+module Amber
+  describe WebSockets::ClientSocket do
+    describe "#on_message" do
+      it "should call `handle_message`" do
+        channel = UserSocket.channels[0][:channel]
+        message = JSON.parse({"event" => "message", "topic" => "user_room:123", "subject" => "msg:new", "payload" => {"message" => "hey guys"}}.to_json)
+        channel.on_message(message)
+        channel.test_field.last.should eq "hey guys"
+      end
+    end
+
+    describe "#subscribe_to_channel" do
+      it "should call `handle_joined`" do
+        ws, client_socket = create_user_socket
+        channel = UserSocket.channels[0][:channel]
+        channel.subscribe_to_channel(client_socket)
+        channel.test_field.last.should eq "handle joined #{client_socket.id}"
+      end
+    end
+
+    describe "#unsubscribe_from_channel" do
+      it "should call `handle_leave`" do
+        ws, client_socket = create_user_socket
+        channel = UserSocket.channels[0][:channel]
+        channel.unsubscribe_from_channel(client_socket)
+        channel.test_field.last.should eq "handle leave #{client_socket.id}"
+      end
+    end
+  end
+end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -82,7 +82,17 @@ struct UserSocket < Amber::WebSockets::ClientSocket
 end
 
 class UserChannel < Amber::WebSockets::Channel
-  def handle_joined; end
+  property test_field = Array(String).new
 
-  def handle_message(msg); end
+  def handle_leave(client_socket)
+    test_field.push("handle leave #{client_socket.id}")
+  end
+
+  def handle_joined(client_socket)
+    test_field.push("handle joined #{client_socket.id}")
+  end
+
+  def handle_message(msg)
+    test_field.push(msg["payload"]["message"].as_s)
+  end
 end

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -5,6 +5,7 @@ require "colorize"
 require "secure_random"
 require "kilt"
 require "kilt/slang"
+require "redis"
 require "./amber/**"
 
 module Amber
@@ -34,6 +35,8 @@ module Amber
     property host : String = "0.0.0.0"
     property port_reuse : Bool = false
     getter key_generator : Amber::Support::CachingKeyGenerator
+    property pubsub_adapter : WebSockets::Adapters::RedisAdapter.class | WebSockets::Adapters::MemoryAdapter.class
+    property redis_url : String
 
     def initialize
       @app_path = __FILE__
@@ -48,6 +51,8 @@ module Amber
       @key_generator = Amber::Support::CachingKeyGenerator.new(
         Amber::Support::KeyGenerator.new(secret, 1000)
       )
+      @pubsub_adapter = WebSockets::Adapters::MemoryAdapter
+      @redis_url = "redis://localhost:6379"
     end
 
     def project_name

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -29,7 +29,7 @@ class HTTP::Server::Context
   end
 
   def invalid_route?
-    !route.payload?
+    !route.payload? && !router.socket_route_defined?(@request)
   end
 
   def websocket?

--- a/src/amber/websockets/adapters/memory.cr
+++ b/src/amber/websockets/adapters/memory.cr
@@ -1,0 +1,22 @@
+module Amber::WebSockets::Adapters
+  # The MemoryAdapter is intended for development use only and shouldn't be used in production.
+  class MemoryAdapter
+    @listeners = Array(NamedTuple(path: String, listener: Proc(JSON::Any, Nil))).new
+
+    def self.instance
+      @@instance ||= new
+    end
+
+    # On *message* publish, just call all listeners procs
+    def publish(topic_path, message)
+      spawn do
+        @listeners.select { |l| l[:path] == topic_path }.each { |l| l[:listener].call(message) }
+      end
+    end
+
+    # Add a channel *listener* as a proc
+    def on_message(topic_path, listener)
+      @listeners.push({path: topic_path, listener: listener})
+    end
+  end
+end

--- a/src/amber/websockets/adapters/redis.cr
+++ b/src/amber/websockets/adapters/redis.cr
@@ -1,0 +1,33 @@
+module Amber::WebSockets::Adapters
+  # Allows websocket connections through redis pub/sub.
+  class RedisAdapter
+    @subscriber : Redis
+    @publisher : Redis
+
+    def self.instance
+      @@instance ||= new
+    end
+
+    # Establish subscribe and publish connections to Redis
+    def initialize
+      @subscriber = Redis.new(url: Amber::Server.instance.redis_url)
+      @publisher = Redis.new(url: Amber::Server.instance.redis_url)
+    end
+
+    # Publish the *message* to the redis publisher with topic *topic_path*
+    def publish(topic_path, message)
+      @publisher.publish(topic_path, message.to_json)
+    end
+
+    # Add a redis subscriber with topic *topic_path*
+    def on_message(topic_path, listener)
+      spawn do
+        @subscriber.subscribe(topic_path) do |on|
+          on.message do |channel, message|
+            listener.call(JSON.parse(message))
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -2,24 +2,74 @@ module Amber
   module WebSockets
     # Sockets subscribe to Channel's, where the communication log is handled.  The channel provides funcionality
     # to handle socket join `handle_joined` and socket messages `handle_message(msg)`.
+    #
+    # Example:
+    #
+    # ```crystal
+    # class ChatChannel < Amber::Websockets::Channel
+    #   def handle_joined(client_socket)
+    #     # functionality when the user joines the channel, optional
+    #   end
+    #
+    #   def handle_leave(client_socket)
+    #     # functionality when the user leaves the channel, optional
+    #   end
+    #
+    #   # functionality when a socket sends a message to a channel, required
+    #   def handle_message(msg)
+    #     rebroadcast!(msg)
+    #   end
+    # end
+    # ```
     abstract class Channel
-      def initialize; end
+      @@adapter : WebSockets::Adapters::RedisAdapter? | WebSockets::Adapters::MemoryAdapter?
+      @topic_path : String
 
-      abstract def handle_joined
       abstract def handle_message(msg)
 
-      protected def subscribe_to_channel
-        handle_joined
+      def handle_joined(client_socket); end
+
+      def handle_leave(client_socket); end
+
+      def initialize(@topic_path); end
+
+      # Called from proc when message is returned from the pubsub service
+      def on_message(message)
+        handle_message(message)
       end
 
-      protected def dispatch(msg)
-        handle_message(msg)
+      # Helper method for retrieving the apdater not nillable
+      protected def adapter
+        setup_pubsub_adapter if @@adapter.nil?
+        @@adapter.not_nil!
+      end
+
+      # Called when a socket subscribes to a channel
+      protected def subscribe_to_channel(client_socket)
+        handle_joined(client_socket)
+      end
+
+      # Called when a socket unsubscribes from a channel
+      protected def unsubscribe_from_channel(client_socket)
+        handle_leave(client_socket)
+      end
+
+      # Sends *message* to the pubsub service
+      protected def dispatch(message)
+        adapter.publish(@topic_path, message)
       end
 
       # Rebroadcast this message to all subscribers of the channel
-      protected def rebroadcast!(msg)
-        subscribers = ClientSockets.get_subscribers_for_topic(msg["topic"])
-        subscribers.each_value(&.socket.send(msg.to_json))
+      # example message: {"event" => "message", "topic" => "rooms:123", "subject" => "msg:new", "payload" => {"message" => "hello"}}
+      protected def rebroadcast!(message)
+        subscribers = ClientSockets.get_subscribers_for_topic(message["topic"])
+        subscribers.each_value(&.socket.send(message.to_json))
+      end
+
+      # Ensure the pubsub adpater instance exists, and set up the on_message proc callback
+      protected def setup_pubsub_adapter
+        @@adapter = Amber::Server.instance.pubsub_adapter.instance
+        @@adapter.not_nil!.on_message(@topic_path, ->(message : JSON::Any) { self.on_message(message); nil })
       end
     end
   end

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -8,8 +8,8 @@ module Amber
     #
     # ```crystal
     # struct UserSocket < Amber::Websockets::ClientSocket
-    #   channel "user_channel/*", UserChannel
-    #   channel "room_channel/*", RoomChannel
+    #   channel "user_channel:*", UserChannel
+    #   channel "room_channel:*", RoomChannel
     #
     #   def on_connect
     #     return some_auth_method!
@@ -24,15 +24,15 @@ module Amber
 
       # Add a channel for this socket to listen, publish to
       def self.channel(channel_path, ch)
-        @@channels.push({path: channel_path, channel: ch.new})
+        @@channels.push({path: channel_path, channel: ch.new(WebSockets.topic_path(channel_path))})
       end
 
       def self.channels
         @@channels
       end
 
-      def self.get_topic_channel(topic)
-        topic_channels = @@channels.select { |ch| ch[:path].split(":")[0] == topic }
+      def self.get_topic_channel(topic_path)
+        topic_channels = @@channels.select { |ch| WebSockets.topic_path(ch[:path]) == topic_path }
         return topic_channels[0][:channel] if topic_channels.any?
       end
 
@@ -42,7 +42,6 @@ module Amber
         @socket.on_pong do |msg|
           # TODO: setup heartbeat
         end
-        self.on_connect
       end
 
       # Authentication and authorization shuould happen here

--- a/src/amber/websockets/client_sockets.cr
+++ b/src/amber/websockets/client_sockets.cr
@@ -1,13 +1,13 @@
 module Amber
   module WebSockets
     #
-    # Manages the entire collection of ClientSocket's.  Manages periodic timers for socket connections (heartbeat).
+    # Manages the entire collection of ClientSockets.  Manages periodic timers for socket connections (heartbeat).
     #
     module ClientSockets
       extend self
       @@client_sockets = Hash(UInt64, ClientSocket).new
       @@heartbeat_started = false
-      BEAT_INTERVAL = 3.seconds
+      BEAT_INTERVAL = 1.minute
 
       def add_client_socket(client_socket)
         @@client_sockets[client_socket.id] = client_socket
@@ -36,8 +36,8 @@ module Amber
       private def heartbeat
         spawn do
           @@heartbeat_started = true
-          @@client_sockets.each_value(&.beat)
           sleep BEAT_INTERVAL
+          @@client_sockets.each_value(&.beat)
           heartbeat
         end
       end

--- a/src/amber/websockets/server.cr
+++ b/src/amber/websockets/server.cr
@@ -35,5 +35,10 @@ module Amber
         end
       end
     end
+
+    # Helper method to get the path of a topic
+    def self.topic_path(topic)
+      topic.to_s.split(":")[0..-2].join(":")
+    end
   end
 end


### PR DESCRIPTION
### Description of the Change

This implements the default pubsub adapter (`MemoryAdapter` to be used only in development) and the `RedisAdpater` to be used in production.  The Redis pubsub adapter allow sockets connected on different processes or even different servers to communicate with each other.

Simple UML diagram of this implementation: https://drive.google.com/open?id=0B2kt7nNk4YTSOEx2UGwwckhTZDg

p.s. I am not very good at UML diagrams

### Why Should This Be In Core?

Without a websocket pubsub adapter, websocket communication is limited to only one server limiting scalability.

### Usage

Inside of the server config block, you can either use the default `MemoryAdapter` (recommended for development only), or `RedisAdapter`

`app.pubsub_adapter = Amber::WebSockets::Adapters::MemoryAdapter` (default)

\- or -

`app.pubsub_adapter = Amber::WebSockets::Adapters::RedisAdapter`