### PR TITLE
HTTP Header Override

### DIFF
--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -1,6 +1,83 @@
 require "../../../spec_helper"
 
 describe HTTP::Server::Context do
+  describe "#override_request_method!" do
+    describe "when X-HTTP-Method-Overrid is present" do
+      it "overrides form POST method to PUT, PATCH, DELETE" do
+        %w(PUT PATCH DELETE).each do |method|
+          header = HTTP::Headers.new
+          header[HTTP::Server::Context::OVERRIDE_HEADER] = method
+          request = HTTP::Request.new("POST", "/?test=test", header)
+
+          context = create_context(request)
+
+          context.request.method.should eq method
+        end
+      end
+
+      it "overrides form GET method to PUT, PATCH, DELETE" do
+        %w(PUT PATCH DELETE).each do |method|
+          header = HTTP::Headers.new
+          header[HTTP::Server::Context::OVERRIDE_HEADER] = method
+          request = HTTP::Request.new("GET", "/?test=test", header)
+
+          context = create_context(request)
+
+          context.request.method.should eq method
+        end
+      end
+
+      it "takes form post over header override" do
+        %w(PUT PATCH DELETE).each do |method|
+          header = HTTP::Headers.new
+          header[HTTP::Server::Context::OVERRIDE_HEADER] = method
+          header["content-type"] = "application/x-www-form-urlencoded"
+          request = HTTP::Request.new("GET", "/?test=test", header, "_method=PATCH")
+
+          context = create_context(request)
+
+          context.request.method.should eq "PATCH"
+        end
+      end
+    end
+
+    it "overrides form POST method to PUT, PATCH, DELETE" do
+      %w(PUT PATCH DELETE).each do |method|
+        header = HTTP::Headers.new
+        header["content-type"] = "application/x-www-form-urlencoded"
+        request = HTTP::Request.new("POST", "/?test=test", header, "_method=#{method}")
+
+        context = create_context(request)
+
+        context.request.method.should eq method
+      end
+    end
+
+    it "overrides form GET method to PUT, PATCH, DELETE" do
+      %w(PUT PATCH DELETE).each do |method|
+        header = HTTP::Headers.new
+        header["content-type"] = "application/x-www-form-urlencoded"
+        request = HTTP::Request.new("GET", "/?test=test", header, "_method=#{method}")
+
+        context = create_context(request)
+
+        context.request.method.should eq method
+      end
+    end
+
+    it "does not override other than PUT, PATCH, DELETE" do
+      %w(PUT PATCH DELETE).each do |method|
+        header = HTTP::Headers.new
+        header["content-type"] = "application/x-www-form-urlencoded"
+        request = HTTP::Request.new("HEAD", "/?test=test", header, "_method=#{method}")
+
+        context = create_context(request)
+
+        context.request.method.should eq "HEAD"
+      end
+    end
+  end
+
   it "parses query params" do
     request = HTTP::Request.new("GET", "/?test=test")
 

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -15,7 +15,7 @@ class HTTP::Server::Context
   def initialize(@request : HTTP::Request, @response : HTTP::Server::Response)
     @router = Amber::Router::Router.instance
     parse_params
-    upgrade_request_method!
+    override_request_method!
     @route = router.match_by_request(@request)
     merge_route_params
   end

--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -13,7 +13,8 @@ module Amber::Router
     MULTIPART_FORM   = "multipart/form-data"
     APPLICATION_JSON = "application/json"
     METHOD           = "_method"
-    OVERRIDE_METHODS = %w(patch put delete)
+    OVERRIDE_HEADER  = "X-HTTP-Method-Override"
+    OVERRIDE_METHODS = %w(PATCH PUT DELETE)
 
     alias ParamTypes = Nil | String | Int64 | Float64 | Bool | Hash(String, JSON::Type) | Array(JSON::Type)
 
@@ -31,11 +32,39 @@ module Amber::Router
       end
     end
 
-    def upgrade_request_method!
-      if params[METHOD]?
-        method = params[METHOD]
-        request.method = method.upcase if OVERRIDE_METHODS.includes?(method)
-      end
+    # Adds Request Method Override support to the framework.
+    # Param supported
+    # - *_method* can be passed as a form or url param
+    #
+    # HTTP Headers supported:
+    # - *X-HTTP-Method* (Microsoft)
+    # - *X-HTTP-Method-Override* (Google/GData)
+    # - *X-METHOD-OVERRIDE* (IBM)
+    #
+    # The convention has been established that the GET and HEAD methods SHOULD NOT
+    # have the significance of taking an action other than retrieval.
+    #
+    # These methods ought to be considered "safe". This allows user agents to
+    # represent other methods, such as POST, PUT and DELETE, in a special way,
+    # so that the user is made aware of the fact that a possibly unsafe action
+    # is being requested.
+    #
+    # Read RFC 2616 - HTTP 1.1 section 9.1.1
+    # (https://tools.ietf.org/html/rfc2616#section-9.1)
+    #
+    # In other words, if you are tempted to use a GET to simulate a PUT or DELETE,
+    # don't do it. Use a POST instead.
+    def override_request_method!
+      # If the current request method is not GET or POST it means that it was
+      # already overrided
+      return unless %(GET POST).includes? request.method
+      method = params[METHOD]? || override_header?
+      request.method = method if method && OVERRIDE_METHODS.includes? method
+    end
+
+    # Determines the existence of HTTP Request Method Override in headers
+    def override_header?
+      request.headers[OVERRIDE_HEADER]?
     end
 
     def merge_route_params

--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -37,9 +37,7 @@ module Amber::Router
     # - *_method* can be passed as a form or url param
     #
     # HTTP Headers supported:
-    # - *X-HTTP-Method* (Microsoft)
     # - *X-HTTP-Method-Override* (Google/GData)
-    # - *X-METHOD-OVERRIDE* (IBM)
     #
     # The convention has been established that the GET and HEAD methods SHOULD NOT
     # have the significance of taking an action other than retrieval.


### PR DESCRIPTION
### Description of the Change

Based on the feedback of this PR https://github.com/Amber-Crystal/amber/pull/115 where it attempts to add method override as an HTTP::Handler 

## Description 
When deploying REST API based web services, you may encounter access
limitations on both the server and client sides. On the server side, the
access to your REST based web application might be done via a proxy web
server that does not support certain HTTP operations such as DELETE or
PUT for security reasons.

Such requests will lead to HTTP 405 error:
Http Status Code: 405
Reason: Request method is not allowed by the server

This PR adds support to offer these operations via POST operations and
ask your clients to add specific X-HTTP method override field in the
header of their requests.

### Benefits
- Keeps the current implementation 
- Maintains support for _method param for overriding
- Adds support http header X-HTTP-Method-Override for overriding

### Requirements
- Add support for HTTP methods PUT PATCH DELETE

