### PR TITLE
Adds different storage mechanisms for session management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
+
+services:
+  - redis-server

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -10,6 +10,28 @@ module Amber::Controller
       end
     end
 
+    describe "#session" do
+      it "responds to cookies" do
+        controller = build_controller("")
+
+        controller.responds_to?(:session).should eq true
+      end
+
+      it "sets a session value" do
+        controller = build_controller("")
+
+        controller.session["name"] = "David"
+
+        controller.session["name"].should eq "David"
+      end
+
+      it "has a session id" do
+        controller = build_controller("")
+
+        controller.session.id.not_nil!.size.should eq 36
+      end
+    end
+
     describe "#render" do
       it "renders html from slang template" do
         request = HTTP::Request.new("GET", "/?test=test")
@@ -45,9 +67,10 @@ module Amber::Controller
       it "renders a form with a csrf tag" do
         request = HTTP::Request.new("GET", "/?test=test")
         context = create_context(request)
+        csrf_token = Amber::Pipe::CSRF.token(context)
         html_output = <<-HTML
         <form action="/posts" method="post">
-          <input type="hidden" name="_csrf" value="#{Amber::Pipe::CSRF.new.token(context)}" />
+          <input type="hidden" name="_csrf" value="#{csrf_token}" />
           <div class="form-group">
             <input class="form-control" type="text" name="title" placeholder="Title" value="hey you">
           </div>

--- a/spec/amber/router/cookies_spec.cr
+++ b/spec/amber/router/cookies_spec.cr
@@ -1,19 +1,4 @@
 require "../../spec_helper"
-KEY_GENERATOR = Amber::Support::CachingKeyGenerator.new(
-  Amber::Support::KeyGenerator.new("secret", 1)
-)
-
-def new_cookie_store(headers = HTTP::Headers.new)
-  cookies = Amber::Router::Cookies::Store.new(KEY_GENERATOR)
-  cookies.update(Amber::Router::Cookies::Store.from_headers(headers))
-  cookies
-end
-
-def cookie_header(cookies)
-  http_headers = HTTP::Headers.new
-  cookies.write(http_headers)
-  http_headers["Set-Cookie"]
-end
 
 module Amber::Router
   describe Cookies::Store do

--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -7,7 +7,9 @@ module Amber
         CSRF::CHECK_METHODS.each do |method|
           it "raises forbbiden error for PUT request" do
             csrf = CSRF.new
+
             request = HTTP::Request.new(method, "/")
+
             expect_raises Exceptions::Forbidden do
               make_router_call(csrf, request)
             end
@@ -31,12 +33,10 @@ module Amber
       context "when tokens match" do
         it "accepts requests params token" do
           csrf = CSRF.new
-          valid_token = "good_token"
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
-
-          context.session["csrf.token"] = valid_token
-          context.params["_csrf"] = valid_token
+          token = CSRF.token(context)
+          context.params[Amber::Pipe::CSRF::PARAM_KEY] = token.to_s
 
           result = csrf.call(context)
 
@@ -45,12 +45,10 @@ module Amber
 
         it "accepts requests for header token" do
           csrf = CSRF.new
-          valid_token = "good_token"
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
-
-          context.session["csrf.token"] = valid_token
-          context.request.headers["HTTP_X_CSRF_TOKEN"] = valid_token
+          token = CSRF.token(context)
+          context.request.headers[Amber::Pipe::CSRF::HEADER_KEY] = token.to_s
 
           result = csrf.call(context)
 

--- a/spec/amber/router/pipe/session_spec.cr
+++ b/spec/amber/router/pipe/session_spec.cr
@@ -6,36 +6,10 @@ module Amber
       it "sets a cookie" do
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
-        session = Session.new
 
-        session.call(context)
+        Session.new.call(context)
 
         context.response.headers.has_key?("set-cookie").should be_true
-      end
-
-      it "encodes the session data" do
-        request = HTTP::Request.new("GET", "/")
-        context = create_context(request)
-        session = Session.new("key.session", "some-secret-key")
-        context.session["authorized"] = "true"
-
-        session.call(context)
-        cookie = context.response.headers["set-cookie"]
-
-        cookie.should eq "key.session=404f0c34f1efcb0d96e0c801fbc0fed13db667b0--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
-      end
-
-      it "uses a secret" do
-        request = HTTP::Request.new("GET", "/")
-        context = create_context(request)
-        session = Session.new("key.session", "some-secret-key")
-        session.secret =
-          context.session["authorized"] = "true"
-
-        session.call(context)
-        cookie = context.response.headers["set-cookie"]
-
-        cookie.should eq "key.session=67b626dc85fd1e1b9c91c3f459bdfcf0902051de--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
       end
     end
   end

--- a/spec/amber/router/session/cookie_store_spec.cr
+++ b/spec/amber/router/session/cookie_store_spec.cr
@@ -1,0 +1,189 @@
+require "../../../../spec_helper"
+
+module Amber::Router::Session
+  COOKIE_STORE = Amber::Router::Cookies::Store.new(Amber::Server.key_generator)
+  EXPIRES = 120 # 2 minutes
+
+  describe CookieStore do
+    describe "#id" do
+      it "returns a UUID" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store.id.not_nil!.size.should eq 36
+      end
+    end
+
+    describe "#destroy" do
+      it "clears session" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["name"] = "David"
+        cookie_store.destroy
+
+        cookie_store.empty?.should be_true
+      end
+    end
+
+    describe "#[]" do
+      it "gets key, value" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["name"] = "David"
+        cookie_store[:name] = "John"
+
+        cookie_store[:name].hash.should eq cookie_store["name"].hash
+        cookie_store[:name].should eq cookie_store["name"]
+        cookie_store["name"].should eq "John"
+      end
+
+      it "raises an KeyError Exception" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        expect_raises KeyError do
+          cookie_store["name"]
+        end
+
+        expect_raises KeyError do
+          cookie_store[:name]
+        end
+      end
+    end
+
+    describe "#[]?" do
+      it "returns true when key exists" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["name"] = "David"
+
+        cookie_store[:name]?.should eq "David"
+        cookie_store["name"]?.should eq "David"
+      end
+
+      it "returns false when key does not exists" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store[:name]?.should eq nil
+        cookie_store["name"]?.should eq nil
+      end
+    end
+
+    describe "#[]=" do
+      it "sets a key value" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["name"] = "David"
+
+        cookie_store[:name].should eq "David"
+        cookie_store["name"].should eq "David"
+      end
+
+      it "updates key value" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["name"] = "David"
+        cookie_store["name"] = "Frank"
+
+        cookie_store[:name].should eq "Frank"
+        cookie_store["name"].should eq "Frank"
+      end
+    end
+
+    describe "#key?" do
+      context "key exists" do
+        it "returns true" do
+          cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+          cookie_store["name"] = "David"
+
+          cookie_store.key?(:name).should eq true
+          cookie_store.key?("name").should eq true
+        end
+      end
+
+      context "key does not exists" do
+        it "returns false" do
+          cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+          cookie_store.key?(:name).should eq false
+          cookie_store.key?("name").should eq false
+        end
+      end
+    end
+
+    describe "#keys" do
+      it "returns a list of available keys" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["a"] = "a"
+        cookie_store[:b] = "c"
+        cookie_store["c"] = "c"
+
+        cookie_store.keys.should eq %w(ses a b c)
+      end
+    end
+
+    describe "#values" do
+      it "returns a list of available keys" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["a"] = "a"
+        cookie_store["b"] = "b"
+        cookie_store[:c] = "c"
+
+        cookie_store.delete("ses")
+
+        cookie_store.values.should eq %w(a b c)
+      end
+    end
+
+    describe "#update" do
+      it "updates all keys by hash" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+        cookie_store["a"] = "a"
+        cookie_store["b"] = "b"
+        cookie_store[:c] = "c"
+
+        cookie_store.update({"a" => "1", "b" => "2", "c" => "3"})
+        cookie_store.delete("ses")
+
+        cookie_store.values.should eq %w(1 2 3)
+      end
+    end
+
+    describe "#fetch" do
+      context "when key is not set" do
+        it "fetches default value" do
+          cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+          cookie_store.fetch("name", "Jordan").should eq "Jordan"
+        end
+      end
+
+      context "when key is set" do
+        it "it fetches previously set value" do
+          cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+          cookie_store["name"] = "Michael"
+
+          cookie_store.fetch("name", "Jordan").should eq "Michael"
+        end
+      end
+    end
+
+    describe "#empty?" do
+      it "returns true when session is empty" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store.empty?.should eq true
+      end
+
+      it "returns false when session is not empty" do
+        cookie_store = CookieStore.new(COOKIE_STORE, "ses", EXPIRES, "secret")
+
+        cookie_store["user_id"] = "1"
+
+        cookie_store.empty?.should eq false
+      end
+    end
+  end
+end

--- a/spec/amber/router/session/redis_store_spec.cr
+++ b/spec/amber/router/session/redis_store_spec.cr
@@ -1,0 +1,200 @@
+require "../../../../spec_helper"
+require "redis"
+
+module Amber::Router::Session
+  REDIS_STORE = Redis.new
+
+  describe RedisStore do
+    describe "#id" do
+      it "returns a UUID" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+        cookie_store.set_session
+
+        cookie_store.id.size.should eq 36
+      end
+    end
+
+    describe "#destroy" do
+      it "clears session" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["name"] = "david"
+        cookie_store.destroy
+
+        cookie_store.empty?.should be_true
+      end
+    end
+
+    describe "#[]" do
+      it "gets key, value" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["name"] = "david"
+        cookie_store["name"].should eq "david"
+      end
+
+      it "throws error if key does not exists" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        expect_raises KeyError do
+          cookie_store["name"]
+        end
+
+        expect_raises KeyError do
+          cookie_store[:name]
+        end
+      end
+    end
+
+    describe "#[]?" do
+      it "returns true when key exists" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["name"] = "david"
+
+        cookie_store["name"]?.should eq "david"
+      end
+
+      it "returns false when key does not exists" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["name"]?.should eq nil
+      end
+    end
+
+    describe "#[]=" do
+      it "sets a key value" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["name"] = "david"
+
+        cookie_store["name"].should eq "david"
+      end
+
+      it "updates key value" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["name"] = "david"
+        cookie_store["name"] = "frank"
+
+        cookie_store["name"].should eq "frank"
+      end
+    end
+
+    describe "#key?" do
+      context "key exists" do
+        it "returns true" do
+          cookies = new_cookie_store
+          cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+          cookie_store["name"] = "david"
+
+          cookie_store.key?("name").should eq true
+        end
+      end
+
+      context "key does not exists" do
+        it "returns false" do
+          cookies = new_cookie_store
+          cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+          cookie_store.key?("name").should eq false
+        end
+      end
+    end
+
+    describe "#keys" do
+      it "returns a list of available keys" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["a"] = "a"
+        cookie_store["b"] = "c"
+        cookie_store["c"] = "c"
+
+        cookie_store.keys.should eq %w(a b c)
+      end
+    end
+
+    describe "#values" do
+      it "returns a list of available keys" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["a"] = "a"
+        cookie_store["b"] = "b"
+        cookie_store["c"] = "c"
+
+        cookie_store.delete("ses")
+
+        cookie_store.values.should eq %w(a b c)
+      end
+    end
+
+    describe "#update" do
+      it "updates all keys by hash" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+        cookie_store["a"] = "a"
+        cookie_store["b"] = "b"
+        cookie_store["c"] = "c"
+
+        cookie_store.update({"a" => "1", "b" => "2", "c" => "3"})
+        cookie_store.delete("ses")
+
+        cookie_store.values.should eq %w(1 2 3)
+      end
+    end
+
+    describe "#fetch" do
+      context "when key is not set" do
+        it "fetches default value" do
+          cookies = new_cookie_store
+          cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+          cookie_store.fetch("name", "Jordan").should eq "Jordan"
+        end
+      end
+
+      context "when key is set" do
+        it "it fetches previously set value" do
+          cookies = new_cookie_store
+          cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+          cookie_store["name"] = "Michael"
+
+          cookie_store.fetch("name", "Jordan").should eq "Michael"
+        end
+      end
+    end
+
+    describe "#empty?" do
+      it "returns true when session is empty" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store.set_session
+
+        cookie_store.empty?.should eq true
+      end
+
+      it "returns false when session is not empty" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store.set_session
+        cookie_store["user_id"] = "1"
+
+        cookie_store.empty?.should eq false
+      end
+    end
+  end
+end

--- a/spec/amber/router/session_factory_spec.cr
+++ b/spec/amber/router/session_factory_spec.cr
@@ -1,0 +1,34 @@
+require "../../../spec_helper"
+
+module Amber::Router
+  describe SessionFactory do
+    it "creates a cookie session store" do
+      cookies = new_cookie_store
+      Amber::Server.instance.session = {
+        :key     => "name.session",
+        :store   => :cookie,
+        :expires => 120,
+        :secret  => "secret",
+      }
+
+      store = SessionFactory.new(cookies)
+
+      store.build.should be_a Session::CookieStore
+    end
+
+    it "creates a redis session store" do
+      cookies = new_cookie_store
+      Amber::Server.instance.session = {
+        :key     => "name.session",
+        :store   => :redis,
+        :expires => 120,
+        :secret  => "secret",
+        :redis_url => "redis://localhost:6379"
+      }
+
+      store = SessionFactory.new(cookies)
+
+      store.build.should be_a Session::RedisStore
+    end
+  end
+end

--- a/spec/support/helpers.cr
+++ b/spec/support/helpers.cr
@@ -1,3 +1,19 @@
+KEY_GENERATOR = Amber::Support::CachingKeyGenerator.new(
+  Amber::Support::KeyGenerator.new("secret", 1)
+)
+
+def new_cookie_store(headers = HTTP::Headers.new)
+  cookies = Amber::Router::Cookies::Store.new(KEY_GENERATOR)
+  cookies.update(Amber::Router::Cookies::Store.from_headers(headers))
+  cookies
+end
+
+def cookie_header(cookies)
+  http_headers = HTTP::Headers.new
+  cookies.write(http_headers)
+  http_headers["Set-Cookie"]
+end
+
 def create_request_and_return_io(router, request)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -26,9 +26,14 @@ module Amber
       instance.key_generator
     end
 
+    def self.session
+      instance.session
+    end
+
+    setter project_name : String?
+    getter key_generator : Amber::Support::CachingKeyGenerator
     property port : Int32
     property name : String
-    setter project_name : String?
     property env : String
     property log : Logger
     property secret : String
@@ -37,6 +42,7 @@ module Amber
     getter key_generator : Amber::Support::CachingKeyGenerator
     property pubsub_adapter : WebSockets::Adapters::RedisAdapter.class | WebSockets::Adapters::MemoryAdapter.class
     property redis_url : String
+    property session : Hash(Symbol, Symbol | Int32 | String)
 
     def initialize
       @app_path = __FILE__
@@ -49,10 +55,17 @@ module Amber
       @host = "0.0.0.0"
       @port_reuse = true
       @key_generator = Amber::Support::CachingKeyGenerator.new(
-        Amber::Support::KeyGenerator.new(secret, 1000)
+        Amber::Support::KeyGenerator.new(secret, 5)
       )
       @pubsub_adapter = WebSockets::Adapters::MemoryAdapter
       @redis_url = "redis://localhost:6379"
+      @session = {
+        :key     => "#{project_name}.session",
+        :store   => :cookie,
+        :expires => 2 * 60 * 60, # 2 Hours
+        :secret  => secret,
+        :redis_url => "redis://localhost:6379"
+      }
     end
 
     def project_name

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -14,20 +14,23 @@ module Amber::Controller
     protected getter context : HTTP::Server::Context
     protected getter params : Amber::Validators::Params
     protected getter flash : Amber::Router::Flash::Params
-    protected getter session : Amber::Router::Session::Params
     protected getter cookies : Amber::Router::Cookies::Store?
+    protected getter session : Amber::Router::Session::AbstractStore?
 
     def initialize(@context : HTTP::Server::Context)
       @request = context.request
       @response = context.response
       @raw_params = context.params
       @flash = context.flash
-      @session = context.session
       @params = Amber::Validators::Params.new(@raw_params)
     end
 
     def cookies
       @cookies ||= context.cookies
+    end
+
+    def session
+      @session ||= context.session
     end
   end
 end

--- a/src/amber/controller/helpers/tags.cr
+++ b/src/amber/controller/helpers/tags.cr
@@ -1,7 +1,15 @@
 module Amber::Controller::Helpers
   module Tag
+    def csrf_token
+      Amber::Pipe::CSRF.token(context).to_s
+    end
+
     def csrf_tag
-      Amber::Pipe::CSRF.new.tag(context)
+      Amber::Pipe::CSRF.tag(context)
+    end
+
+    def csrf_metatag
+      Amber::Pipe::CSRF.metatag(context)
     end
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -11,8 +11,8 @@ class HTTP::Server::Context
 
   property route : Radix::Result(Amber::Route)
   getter router : Amber::Router::Router
-
-  @cookies : Amber::Router::Cookies::Store?
+  setter cookies : Amber::Router::Cookies::Store?
+  setter session : Amber::Router::Session::AbstractStore?
 
   def initialize(@request : HTTP::Request, @response : HTTP::Server::Response)
     @router = Amber::Router::Router.instance
@@ -26,6 +26,10 @@ class HTTP::Server::Context
     @cookies ||= Amber::Router::Cookies::Store.build(
       request, Amber::Server.key_generator
     )
+  end
+
+  def session
+    @session ||= Amber::Router::SessionFactory.new(cookies).build
   end
 
   def invalid_route?

--- a/src/amber/router/pipe/session.cr
+++ b/src/amber/router/pipe/session.cr
@@ -9,71 +9,11 @@ module Amber
     # encode and decode the cookie and provide the hash in the context that can
     # be used to maintain data across requests.
     class Session < Base
-      property secret : String
-      property key : String
-      property store : Symbol
-
-      def initialize(@key : String = "#{Server.settings.project_name}.session",
-                     @secret : String = Server.settings.secret,
-                     @store : Symbol = :cookie)
-      end
-
       def call(context : HTTP::Server::Context)
-        cookies = context.request.cookies
-        decode(context.session, cookies[@key].value) if cookies.has_key?(@key)
         call_next(context)
-        value = encode(context.session.as(Hash))
-        cookies = context.response.cookies
-        cookies << HTTP::Cookie.new(@key, value)
-        cookies.add_response_headers(context.response.headers)
+        context.session.set_session
+        context.cookies.write(context.response.headers)
         context
-      end
-
-      private def decode(session, data)
-        sha1, data = data.split("--", 2)
-        if sha1 == OpenSSL::HMAC.hexdigest(:sha1, @secret, data)
-          values = YAML.parse(Base64.decode_string(data))
-          values.each do |key, value|
-            session[key.to_s] = value.to_s
-          end
-        end
-      end
-
-      private def encode(session)
-        data = Base64.encode(session.to_yaml)
-        sha1 = OpenSSL::HMAC.hexdigest(:sha1, @secret, data)
-        "#{sha1}--#{data}"
-      end
-    end
-  end
-
-  module Router
-    module Session
-      # clear the session.  You can call this to logout a user.
-      def clear_session
-        @session = Params.new
-      end
-
-      # Holds a hash of session variables.  This can be used to hold data between
-      # sessions.  It's recommended to avoid holding any private data in the
-      # session since this is held in a cookie.  Also avoid putting more than 4k
-      # worth of data in the session to avoid slow pageload times.
-      def session
-        @session ||= Params.new
-      end
-
-      class Params < Hash(String, String)
-        def []=(key : String | Symbol, value : V)
-          super(key.to_s, value)
-        end
-
-        def [](key)
-          fetch(key, nil)
-        end
-
-        def find_entry(key)
-          super(key.to_s)
-        end
       end
     end
   end

--- a/src/amber/router/session/abstract_store.cr
+++ b/src/amber/router/session/abstract_store.cr
@@ -1,0 +1,18 @@
+module Amber::Router::Session
+  # All Session Stores should implement the following API
+  abstract class AbstractStore
+    abstract def id
+    abstract def destroy
+    abstract def [](key : String | Symbol)
+    abstract def []?(key : String | Symbol)
+    abstract def []=(key : String | Symbol, value)
+    abstract def key?(key : String | Symbol)
+    abstract def keys
+    abstract def values
+    abstract def to_h
+    abstract def update(other_hash)
+    abstract def delete(key : String | Symbol)
+    abstract def fetch(key : String | Symbol, default = nil)
+    abstract def empty?
+  end
+end

--- a/src/amber/router/session/cookie_store.cr
+++ b/src/amber/router/session/cookie_store.cr
@@ -1,0 +1,80 @@
+module Amber::Router::Session
+  # This is the default Cookie Store
+  class CookieStore < AbstractStore
+    property secret : String
+    property key : String
+    property expires : Int32
+    property store : Amber::Router::Cookies::Store
+    property session : Hash(String, String)
+
+    def initialize(@store, @key, @expires, @secret)
+      @session = current_session
+      @session[key] = SecureRandom.uuid
+    end
+
+    def id
+      @session[key]
+    end
+
+    def destroy
+      @session.clear
+    end
+
+    def [](key : String | Symbol)
+      @session.fetch(key.to_s)
+    end
+
+    def []?(key : String | Symbol)
+      fetch(key.to_s, nil)
+    end
+
+    def []=(key : String | Symbol, value)
+      @session[key.to_s] = value.to_s
+    end
+
+    def key?(key : String | Symbol)
+      @session.has_key?(key.to_s)
+    end
+
+    def keys
+      @session.keys
+    end
+
+    def values
+      @session.values
+    end
+
+    def to_h
+      @session
+    end
+
+    def update(hash : Hash(String | Symbol, String))
+      hash.each do |key, value|
+        @session[key.to_s] = value
+      end
+      @session
+    end
+
+    def delete(key : String | Symbol)
+      @session.delete(key.to_s) if key?(key.to_s)
+    end
+
+    def fetch(key : String | Symbol, default = nil)
+      @session.fetch(key.to_s, default)
+    end
+
+    def empty?
+      @session.select { |_key, _| _key != key }.empty?
+    end
+
+    def set_session
+      store.encrypted.set(key, session.to_json, expires: (Time.now + expires.seconds), http_only: true)
+    end
+
+    def current_session
+      Hash(String, String).from_json(@store.encrypted[key] || "{}")
+    rescue e : JSON::ParseException
+      Hash(String, String).new
+    end
+  end
+end

--- a/src/amber/router/session/redis_store.cr
+++ b/src/amber/router/session/redis_store.cr
@@ -1,0 +1,80 @@
+require "redis"
+
+module Amber::Router::Session
+  class RedisStore < AbstractStore
+    getter store : Redis
+    property expires : Int32
+    property key : String
+    property session_id : String
+    property cookies : Amber::Router::Cookies::Store
+    property id : String
+
+    def initialize(@store, @cookies, @key, @expires = 120)
+      @id = current_session
+      @session_id = "#{@key}:#{@id}"
+    end
+
+    def destroy
+      @store.del(session_id)
+    end
+
+    def [](key : String | Symbol)
+      return @store.hget(@session_id, key.to_s) if key?(key.to_s)
+      raise KeyError.new "Missing hash key: #{key.inspect}"
+    end
+
+    def []?(key : String | Symbol)
+      fetch(key.to_s, nil)
+    end
+
+    def []=(key : String | Symbol, value)
+      @store.hset(session_id, key.to_s, value)
+    end
+
+    def key?(key : String | Symbol)
+      @store.hexists(session_id, key.to_s) == 1 ? true : false
+    end
+
+    def keys
+      @store.hkeys(session_id)
+    end
+
+    def values
+      @store.hvals(session_id)
+    end
+
+    def to_h
+      @store.hmget(session_id).each_slice(2).to_h
+    end
+
+    def update(hash : Hash(String, String))
+      @store.hmset(session_id, hash)
+    end
+
+    def delete(key : String | Symbol)
+      @store.hdel(session_id, key.to_s) if key?(key.to_s)
+    end
+
+    def fetch(key : String | Symbol, default = nil)
+       @store.hget(session_id, key.to_s) || default
+    end
+
+    def empty?
+      # 1 since the session id key always gets set technically is never empty
+      @store.hlen(session_id) <= 1
+    end
+
+    def set_session
+      cookies.encrypted.set(key, session_id, expires: (Time.now + expires.seconds), http_only: true)
+
+      store.pipelined do |pipeline|
+        pipeline.hset(session_id, key, id)
+        pipeline.expire(session_id, expires)
+      end
+    end
+
+    def current_session
+      @cookies.encrypted[@key] || SecureRandom.uuid
+    end
+  end
+end

--- a/src/amber/router/session_factory.cr
+++ b/src/amber/router/session_factory.cr
@@ -1,0 +1,29 @@
+module Amber::Router
+  class SessionFactory
+    property session : Hash(Symbol, Symbol | Int32 | String)
+    property cookies : Cookies::Store
+    getter session_store : Session::AbstractStore?
+
+    def initialize(@cookies)
+      @session = Amber::Server.session
+    end
+
+    def build : Session::AbstractStore
+      @session_store ||= case session[:store]
+                         when :redis
+                           redis
+                         else
+                           cookie
+                         end
+    end
+
+    def redis
+      store = Redis.new(url: session[:redis_url].to_s)
+      Session::RedisStore.new(store, cookies, session[:key].to_s, session[:expires].to_i)
+    end
+
+    def cookie
+      Session::CookieStore.new(cookies, session[:key].to_s, session[:expires].to_i, session[:secret].to_s)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Your application has a session for each user in which you can store small amounts of data that will be persisted between requests. The session is only available in the controller and the view and can use one of a number of different storage mechanisms:
****
This PR adds the following storage mechanism:
- Adds Cookies Session using new cookies storage
- Adds Redis Session storage

```
Amber::Session::CookieStore
Amber::Session::RedisStore
# Todo 
Amber::Session::DBStore
Amber::Session::MemCacheStore
```

All session stores use a cookie to store a unique ID for each session (you must use a cookie, Amber will not allow you to pass the session ID in the URL as this is less secure).

For most stores, this ID is used to look up the session data on the server, e.g. in a database table. There is one exception, and that is the default and recommended session store - the CookieStore - which stores all session data in the cookie itself (the ID is still available to you if you need it). This has the advantage of being very lightweight and it requires zero setup in a new application in order to use the session. The cookie data is cryptographically signed to make it tamper-proof. And it is also encrypted so anyone with access to it can't read its contents. (Amber will not accept it if it has been edited).

**Impportant**

About Session Cookie Store
- You can only store about 4kb of data in a cookie.
- Cookies are sent along with every request you make.
- If you accidentally expose your secret_key_base, your users can change the data you’ve put inside your cookie.

About Redis Store
- You can store more than 4kb of data in the session, only the session id gets stored in the cookie.
- This means smaller request 

## Configuration

```cr
@session = {
        :key     => "#{project_name}.session",
        :store   => :cookie, # :redis, must provide redis URL
        :expires => 2 * 60 * 60, # 2 Hours
        :secret  => secret,
        :redis_url => "redis://localhost:6379"
      }
```
**Accessing Session**
Session values are stored using key/value pairs like a hash:
```cr
class ApplicationController < Amber::Controller::Base
  # Finds the User with the ID stored in the session with the key
  # **:current_user_id** This is a common way to handle user login in
  # an Amber application; logging in sets the session value and
  # Logging out removes it.
  private def current_user
    @_current_user ||= session[:current_user_id] &&
      User.find_by(id: session[:current_user_id])
  end
end
```
To store something in the session, just assign it to the key like a hash:
```cr
class LoginsController < ApplicationController
  # "Create" a login, aka "log the user in"
  def create
    if user = User.authenticate(params[:username], params[:password])
      # Save the user ID in the session so it can be used in
      # subsequent requests
      session[:current_user_id] = user.id
      redirect_to root_url
    end
  end
end
```
To remove something from the session

```cr

class LoginsController < ApplicationController
  # "Delete" a login, aka "log the user out"
  def destroy
    # Remove the user id from the session
    session.delete[:current_user_id] 
    redirect_to root_url
  end
end
```

## Extending Creating your own session store

To create new session store must follow the **Amber::Router::Session::AbstractStore** interface.