### PR TITLE
Session only writes to cookies if it has changed. 

### DIFF
--- a/spec/amber/router/pipe/session_spec.cr
+++ b/spec/amber/router/pipe/session_spec.cr
@@ -7,7 +7,7 @@ module Amber
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
         session = Session.new
-
+        session.next = -> (context : HTTP::Server::Context){context.session["test"] = "test"}
         session.call(context)
 
         context.response.headers.has_key?("set-cookie").should be_true
@@ -22,20 +22,19 @@ module Amber
         session.call(context)
         cookie = context.response.headers["set-cookie"]
 
-        cookie.should eq "key.session=404f0c34f1efcb0d96e0c801fbc0fed13db667b0--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
+        cookie.should eq "key.session=8a45be69c9e296834650a6e73c50f931a60d6cf8--eyJhdXRob3JpemVkIjoidHJ1ZSJ9%0A; path=/"
       end
 
       it "uses a secret" do
         request = HTTP::Request.new("GET", "/")
         context = create_context(request)
         session = Session.new("key.session", "some-secret-key")
-        session.secret =
-          context.session["authorized"] = "true"
+        context.session["authorized"] = "true"
 
         session.call(context)
         cookie = context.response.headers["set-cookie"]
 
-        cookie.should eq "key.session=67b626dc85fd1e1b9c91c3f459bdfcf0902051de--LS0tCmF1dGhvcml6ZWQ6IHRydWUK%0A; path=/"
+        cookie.should eq "key.session=8a45be69c9e296834650a6e73c50f931a60d6cf8--eyJhdXRob3JpemVkIjoidHJ1ZSJ9%0A; path=/"
       end
     end
   end


### PR DESCRIPTION
### Description of the Change

Session doesn’t need to serialize, sign and write to cookies if it hasn’t changed. This saves a ton of time.

### Benefits

Results in 3x (10,000req/s to 33,000req/s MBP singlecore) speed increase when session isn't being set and no noticeable difference when it is.

### Possible Drawbacks

This code will all be replaced soon.