### PR TITLE
Fixes Static File Handler

### DIFF
--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -13,13 +13,6 @@ module Amber
         @directory_listing = directory_listing
       end
 
-      def initialize
-        @public_dir = File.expand_path "./public"
-        @default_file = "index.html"
-        @fallthrough = true
-        @static_config = {"dir_listing" => false, "gzip" => true}
-      end
-
       def call(context : HTTP::Server::Context)
         return call_next(context) if context.request.path.not_nil! == "/"
 

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -5,7 +5,7 @@ module Amber
     class Static < HTTP::StaticFileHandler
       property default_file, public_dir
 
-      def initialize(public_dir : String, directory_liting = false, fallthrough = true)
+      def initialize(public_dir : String, directory_listing = false, fallthrough = true)
         @public_dir = File.expand_path public_dir
         @fallthrough = !!fallthrough
         @default_file = "index.html"

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -5,11 +5,12 @@ module Amber
     class Static < HTTP::StaticFileHandler
       property default_file, public_dir
 
-      def initialize(public_dir : String, fallthrough = true)
+      def initialize(public_dir : String, directory_liting = false, fallthrough = true)
         @public_dir = File.expand_path public_dir
         @fallthrough = !!fallthrough
         @default_file = "index.html"
         @static_config = {"dir_listing" => false, "gzip" => true}
+        @directory_listing = directory_listing
       end
 
       def initialize


### PR DESCRIPTION
Static File Handler has changed in crystal version 0.23

This adds a new argument called directory listing to the static handler
which allows to comply to the new changes in Crystal 0.23

* Directory listting can now be specified when adding the handler to the
pipeline

```crystal
pipeline :web do
  pipe Amber::Pipe::Static.new "/public", true # public directory, directory listing.
end
```

This makes it backwards compatible with crystal 0.22 and 0.23

Thank you @sdogruyol