### PR TITLE
websockets heartbeat

### DIFF
--- a/spec/amber/websockets/client_socket_spec.cr
+++ b/spec/amber/websockets/client_socket_spec.cr
@@ -9,6 +9,18 @@ module Amber
       end
     end
 
+    describe "#get_topic_channel" do
+      it "should return the channel if it exists" do
+        channel = UserSocket.get_topic_channel("user_room")
+        channel.should_not be_nil
+      end
+
+      it "should return nil if channel does not exist" do
+        channel = UserSocket.get_topic_channel("non_existent_room")
+        channel.should be_nil
+      end
+    end
+
     describe "#initialize" do
       it "should set the socket and socket id" do
         ws, client_socket = create_user_socket
@@ -22,6 +34,26 @@ module Amber
       it "should default to true" do
         ws, client_socket = create_user_socket
         client_socket.on_connect.should be_true
+      end
+    end
+
+    describe "#disconnect!" do
+      it "it should close the socket" do
+        http_server, ws = create_socket_server
+        client_socket = Amber::WebSockets::ClientSockets.client_sockets.values.first
+        client_socket.disconnect!
+        client_socket.socket.closed?.should be_true
+        ws.close
+        http_server.not_nil!.close
+      end
+
+      it "should remove the client socket from the ClientSockets list" do
+        http_server, ws = create_socket_server
+        client_socket = Amber::WebSockets::ClientSockets.client_sockets.values.first
+        client_socket.disconnect!
+        Amber::WebSockets::ClientSockets.client_sockets.keys.size.should eq 0
+        ws.close
+        http_server.not_nil!.close
       end
     end
 

--- a/spec/amber/websockets/client_sockets_spec.cr
+++ b/spec/amber/websockets/client_sockets_spec.cr
@@ -8,6 +8,7 @@ module Amber
         WebSockets::ClientSockets.add_client_socket(client_socket)
 
         WebSockets::ClientSockets.client_sockets[client_socket.id].should eq client_socket
+        WebSockets::ClientSockets.remove_client_socket(client_socket)
       end
     end
 
@@ -30,6 +31,8 @@ module Amber
         client_socket1.on_message({event: "join", topic: "user_room:123"}.to_json)
         client_socket2.on_message({event: "join", topic: "user_room:123"}.to_json)
         WebSockets::ClientSockets.get_subscribers_for_topic("user_room:123").values.should eq [client_socket1, client_socket2]
+        WebSockets::ClientSockets.remove_client_socket(client_socket1)
+        WebSockets::ClientSockets.remove_client_socket(client_socket2)
       end
     end
   end

--- a/spec/support/helpers.cr
+++ b/spec/support/helpers.cr
@@ -53,3 +53,20 @@ def create_user_socket
   client_socket = UserSocket.new(ws)
   return ws, client_socket
 end
+
+def create_socket_server
+  port_chan = Channel(Int32).new
+  http_ref = nil
+
+  spawn do
+    handler = Amber::WebSockets::Server.create_endpoint("/", UserSocket)
+    http_server = http_ref = HTTP::Server.new(0, [handler])
+    http_server.bind
+    port_chan.send(http_server.port)
+    http_server.listen
+  end
+
+  listen_port = port_chan.receive
+  ws = HTTP::WebSocket.new("ws://127.0.0.1:#{listen_port}")
+  return http_ref.not_nil!, ws
+end

--- a/src/amber/websockets/server.cr
+++ b/src/amber/websockets/server.cr
@@ -4,24 +4,20 @@ module Amber
       extend self
 
       def create_endpoint(path, app_socket)
-        spawn do
-          Amber::Server.instance.log.info "socket listening at #{path}"
-          Handler.new(path) do |socket|
-            instance = app_socket.new(socket)
-            socket.close && next unless instance.authorized?
+        Amber::Server.instance.log.info "socket listening at #{path}"
+        Handler.new(path) do |socket|
+          instance = app_socket.new(socket)
+          socket.close && next unless instance.authorized?
 
-            ClientSockets.add_client_socket(instance)
+          ClientSockets.add_client_socket(instance)
 
-            socket.on_message do |message|
-              instance.on_message(message)
-            end
-
-            socket.on_close do
-              ClientSockets.remove_client_socket(instance)
-            end
+          socket.on_message do |message|
+            instance.on_message(message)
           end
 
-          ClientSockets.setup_heartbeat
+          socket.on_close do
+            ClientSockets.remove_client_socket(instance)
+          end
         end
       end
 


### PR DESCRIPTION
closes #82 

### Description of the Change

Websockets heartbeat is necessary to prevent stale connections.  The `ClientSockets` module will manage the creation of the heartbeat for each client socket.  Each `ClientSocket` is responsible for handling its own pings and pongs.  A ping is sent every 5 minutes.  After 3 pings have been sent (15 minutes) if no pongs have been received from the client or a pong hasnt been received for over 16 minutes (15 minutes plus 1 minute grace period) the client is disconnected.

* Previously the `ClientSockets` was sending a ping to every socket every x interval.  This was bad design as all client would get pinged at the same time, with thousands of clients connected I could see where this could cause issues.  Instead now the pings are spread out and each client socket has its own schedule for pings.

* Creating the socket endpoint was previously done in a new fiber.  This was unnecessary, and removing it allowed me to test the handler.
