### PR TITLE
Removes colorize Yellow from env variable

### DIFF
--- a/src/amber.cr
+++ b/src/amber.cr
@@ -48,7 +48,7 @@ module Amber
       @app_path = __FILE__
       @name = "amber_project"
       @port = 8080
-      @env = "development".colorize(:yellow).to_s
+      @env = "development".to_s
       @log = ::Logger.new(STDOUT)
       @log.level = ::Logger::INFO
       @secret = ENV["SECRET_KEY_BASE"]? || SecureRandom.hex(128)
@@ -103,7 +103,7 @@ module Amber
         exit
       end
 
-      log.info "Server started in #{env}.".to_s
+      log.info "Server started in #{env.colorize(:yellow)}.".to_s
       log.info "Startup Time #{Time.now - time}\n\n".colorize(:white).to_s
       server.listen(port_reuse)
     end


### PR DESCRIPTION
## Removes colorize Yellow from env variable

Instead of setting the App.env to be colorize at initialization we do
this when printing out log information, this avoids having wierd
characters as part of the App.env variable.

Addresses Issue https://github.com/Amber-Crystal/amber/issues/133