### PR TITLE
public broadcast method, socket sessions

### DIFF
--- a/spec/amber/websockets/channel_spec.cr
+++ b/spec/amber/websockets/channel_spec.cr
@@ -15,7 +15,7 @@ module Amber
       it "should call `handle_joined`" do
         ws, client_socket = create_user_socket
         channel = UserSocket.channels[0][:channel]
-        channel.subscribe_to_channel(client_socket)
+        channel.subscribe_to_channel(client_socket, "{}")
         channel.test_field.last.should eq "handle joined #{client_socket.id}"
       end
     end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -93,7 +93,7 @@ class UserChannel < Amber::WebSockets::Channel
     test_field.push("handle leave #{client_socket.id}")
   end
 
-  def handle_joined(client_socket)
+  def handle_joined(client_socket, msg)
     test_field.push("handle joined #{client_socket.id}")
   end
 

--- a/spec/support/helpers.cr
+++ b/spec/support/helpers.cr
@@ -49,8 +49,9 @@ def build_controller(referer)
 end
 
 def create_user_socket
+  request = HTTP::Request.new("GET", "/")
   ws = HTTP::WebSocket.new(STDOUT)
-  client_socket = UserSocket.new(ws)
+  client_socket = UserSocket.new(ws, create_context(request))
   return ws, client_socket
 end
 
@@ -68,5 +69,6 @@ def create_socket_server
 
   listen_port = port_chan.receive
   ws = HTTP::WebSocket.new("ws://127.0.0.1:#{listen_port}")
+  spawn { ws.run }
   return http_ref.not_nil!, ws
 end

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -27,7 +27,8 @@ module Amber
 
       abstract def handle_message(msg)
 
-      def handle_joined(client_socket); end
+      # Authorization can happen here
+      def handle_joined(client_socket, message); end
 
       def handle_leave(client_socket); end
 
@@ -45,8 +46,8 @@ module Amber
       end
 
       # Called when a socket subscribes to a channel
-      protected def subscribe_to_channel(client_socket)
-        handle_joined(client_socket)
+      protected def subscribe_to_channel(client_socket, message)
+        handle_joined(client_socket, message)
       end
 
       # Called when a socket unsubscribes from a channel

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -22,8 +22,13 @@ module Amber
       MAX_SOCKET_IDLE_TIME = 16.minutes
       BEAT_INTERVAL        = 5.minutes
 
-      property id : UInt64
-      property socket : HTTP::WebSocket
+      protected getter id : UInt64
+      getter socket : HTTP::WebSocket
+      protected getter context : HTTP::Server::Context
+      protected getter raw_params : HTTP::Params
+      protected getter params : Amber::Validators::Params
+      protected getter session : Amber::Router::Session::AbstractStore?
+      protected getter cookies : Amber::Router::Cookies::Store?
       private property pongs = Array(Time).new
       private property pings = Array(Time).new
 
@@ -41,16 +46,42 @@ module Amber
         return topic_channels[0][:channel] if topic_channels.any?
       end
 
-      def initialize(@socket)
+      # Broadcast a message to all subscribres of the topic
+      #
+      # ```crystal
+      # UserSocket.broadcast("message", "chats_room:1", "msg:new", {"message" => "test"})
+      # ```
+      protected def self.broadcast(event : String, topic : String, subject : String, payload : Hash)
+        if channel = get_topic_channel(WebSockets.topic_path(topic))
+          channel.rebroadcast!({
+            "event"   => event,
+            "topic"   => topic,
+            "subject" => subject,
+            "payload" => payload,
+          })
+        end
+      end
+
+      def initialize(@socket, @context)
         @id = @socket.object_id
         @subscription_manager = SubscriptionManager.new
+        @raw_params = @context.params
+        @params = Amber::Validators::Params.new(@raw_params)
         @socket.on_pong do |msg|
           @pongs.push(Time.now)
           @pongs.delete_at(0) if @pongs.size > 3
         end
       end
 
-      # Authentication and authorization should happen here
+      def session
+        @session ||= @context.session
+      end
+
+      def cookies
+        @cookies ||= @context.cookies
+      end
+
+      # Authentication and authorization can happen here
       def on_connect : Bool
         true
       end
@@ -82,11 +113,11 @@ module Amber
         if @socket.closed?
           Amber::Server.instance.log.error "Ignoring message sent to closed socket"
         else
-          @subscription_manager.dispatch self, decode(message)
+          @subscription_manager.dispatch self, decode_message(message)
         end
       end
 
-      protected def decode(message)
+      protected def decode_message(message)
         # TODO: implement different decoders
         JSON.parse(message)
       end

--- a/src/amber/websockets/server.cr
+++ b/src/amber/websockets/server.cr
@@ -5,8 +5,8 @@ module Amber
 
       def create_endpoint(path, app_socket)
         Amber::Server.instance.log.info "socket listening at #{path}"
-        Handler.new(path) do |socket|
-          instance = app_socket.new(socket)
+        Handler.new(path) do |socket, context|
+          instance = app_socket.new(socket, context)
           socket.close && next unless instance.authorized?
 
           ClientSockets.add_client_socket(instance)

--- a/src/amber/websockets/subscription_manager.cr
+++ b/src/amber/websockets/subscription_manager.cr
@@ -21,7 +21,7 @@ module Amber
       private def join(client_socket, message)
         return if subscriptions[message["topic"]]?
         if channel = client_socket.class.get_topic_channel(WebSockets.topic_path(message["topic"]))
-          channel.subscribe_to_channel(client_socket)
+          channel.subscribe_to_channel(client_socket, message)
           subscriptions[message["topic"].as_s] = channel
         end
       end


### PR DESCRIPTION
### Description of the Change

This adds session and cookie context to `ClientSocket`.  This allows the user to authenticate websockets with already existing authentication schemes (sessions / cookies).

This also adds a `ClientSocket#broadcast` method, which allows the user to broadcast from somewhere outside of the context of websockets (i.e. from a controller action).

example: 
`UserSocket.broadcast("message", "user_room:939", "msg:new", {"message" => "test"})`

**Breaking Change**
* `handle_joined` now accepts 2 parameters: the socket and the message - This allows for authorization when a user tries to join a channel - @mixflame this might affect your existing application thats using websockets