### PR TITLE
Render using absolute path

### DIFF
--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -6,7 +6,11 @@ module Amber::Controller
       {% if filename.id.split("/").size > 2 %}
         Kilt.render("{{filename.id}}")
       {% else %}
-        Kilt.render("#{{{path}}}/{{filename.id}}")
+        {% if path == "src/views" %}
+          Kilt.render("{{__FILE__.split('/')[0..-4].join('/').id}}/#{{{path}}}/{{filename.id}}")
+        {% else %}
+          Kilt.render("#{{{path}}}/{{filename.id}}")
+        {% end %}
       {% end %}
     end
 


### PR DESCRIPTION
### Description of the Change

This PR add absolute path to macro render_template.

### Alternate Designs

The absolute path is used if path is equal to `"src/view"`

### Why Should This Be In Core?

Currently in my amber projects I have to rewrite the macro `render_template` adding support for absolute path, because [vscode-crystal-lang](https://github.com/faustinoaq/vscode-crystal-lang) extension can't find relative paths when analyze code.

My `application_controller.cr`

```crystal
class ApplicationController < Amber::Controller::Base
  LAYOUT = "application.ecr"

  macro render_template(filename, path = "src/views")
    {% if filename.id.split("/").size > 2 %}
      Kilt.render("{{filename.id}}")
    {% else %}
      {% if path == "src/views" %}
        Kilt.render("{{__FILE__.split('/')[0..-4].join('/').id}}/#{{{path}}}/{{filename.id}}")
      {% else %}
        Kilt.render("#{{{path}}}/{{filename.id}}")
      {% end %}
    {% end %}
  end
end
```

Some screenshots:

Show macro errors related to relative path of views:

![screenshot_20170721_205722](https://user-images.githubusercontent.com/3067335/28487560-d2730ab4-6e58-11e7-8472-29c7ce39f60e.png)

Errors fixed using absolute path:

![screenshot_20170721_205917](https://user-images.githubusercontent.com/3067335/28487568-f4e3087e-6e58-11e7-8808-d9a157f37a6e.png)

### Benefits

This change add absolute path only if path is equal to `"src/view"` so, if path change the render process uses the path given.

### Possible Drawbacks

Absolute path is calculated using `__FILE__` only when path is default to views folder, if path changes then absolute path isn't used.

### Applicable Issues

Editor extensions like [Scry](https://github.com/kofno/scry) can't find relative paths used by macros, so this PR help to users to avoid unnecessary macro errors.
