### PR TITLE
[WIP] Ep/halt request lifecycle

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -211,11 +211,11 @@ module Amber::Controller
 
   describe "#halt" do
     it "raises and Amber::Exceptions::HaltRequest error" do
-        controller = build_controller("")
+      controller = build_controller("")
 
-        controller.halt(status_code = 800, output = "Message")
+      controller.halt(status_code = 800, output = "Message")
 
-        controller.response.status_code.should eq 800
+      controller.response.status_code.should eq 800
     end
   end
 end

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -54,15 +54,6 @@ module Amber::Controller
         TestController.new(context).render_partial.should eq html_output
       end
 
-      it "renders flash message" do
-        request = HTTP::Request.new("GET", "/")
-        context = create_context(request)
-
-        controller = TestController.new(context)
-
-        controller.render_with_flash
-      end
-
       it "renders html and layout from slang template" do
         request = HTTP::Request.new("GET", "/?test=test")
         context = create_context(request)
@@ -215,6 +206,16 @@ module Amber::Controller
           response.status_code.should eq 301
         end
       end
+    end
+  end
+
+  describe "#halt" do
+    it "raises and Amber::Exceptions::HaltRequest error" do
+        controller = build_controller("")
+
+        controller.halt(status_code = 800, output = "Message")
+
+        controller.response.status_code.should eq 800
     end
   end
 end

--- a/spec/amber/route_spec.cr
+++ b/spec/amber/route_spec.cr
@@ -4,7 +4,8 @@ module Amber
   describe Route do
     it "Initializes correctly with Decendant controller" do
       handler = ->(context : HTTP::Server::Context, action : Symbol) {
-        "Hey yo world!"
+          context.response.print "Hey yo world!"
+          context.response.close
       }
       request = HTTP::Request.new("GET", "/?test=test")
       context = create_context(request)

--- a/spec/amber/router/cookies_spec.cr
+++ b/spec/amber/router/cookies_spec.cr
@@ -180,7 +180,6 @@ module Amber::Router
         cookies.signed["user_name"].should eq ""
       end
 
-
       it "ignores unset encrypted cookies" do
         cookies = new_cookie_store
 

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -1,0 +1,92 @@
+require "../../../spec_helper"
+
+module Amber
+  module Router
+    describe Route do
+      describe "#call" do
+        it "performs request lifecycle" do
+          method = "GET"
+          action = :show
+          request = HTTP::Request.new(method, "/#{action}")
+          context = create_context(request)
+          route = Route.new("GET",
+            "/#{action}",
+            build_handler(action, context),
+            action,
+            :web,
+            "",
+            "FakeController")
+
+          result = route.call(context)
+
+          context.response.status_code.should eq 200
+        end
+
+        it "halts request lifecycle" do
+          method = "GET"
+          action = :halt_request
+          request = HTTP::Request.new(method, "/#{action}")
+          context = create_context(request)
+          route = Route.new("GET",
+            "/#{action}",
+            build_handler(action, context),
+            action,
+            :web,
+            "",
+            "FakeController")
+
+          result = route.call(context)
+
+          context.response.status_code.should eq 800
+        end
+      end
+    end
+  end
+end
+
+class FakeController < Amber::Controller::Base
+  before_action do
+    only :halt_request { halt_lifecycle }
+  end
+
+  def show
+    "Action show result"
+  end
+
+  def halt_lifecycle
+    halt(status_code = 800)
+  end
+
+  def halt_request
+    "Should not be in request"
+  end
+end
+
+def build_handler(action, context)
+  handler = ->(context : HTTP::Server::Context, action : Symbol) {
+    controller = FakeController.new(context)
+    controller.run_before_filter(:all)
+    controller.run_before_filter(action)
+    content = controller.show
+    puts context.response.status_code
+    controller.run_after_filter(action)
+    controller.run_after_filter(:all)
+    context.response.print content
+    context.response.close
+  }
+end
+
+def build_halt_handler(action, context)
+  handler = ->(context : HTTP::Server::Context, action : Symbol) {
+    controller = FakeController.new(context)
+    controller.run_before_filter(:all)
+    controller.run_before_filter(action)
+    content = controller.halt_request
+    puts context.response.status_code
+    controller.run_after_filter(action)
+    controller.run_after_filter(:all)
+    context.response.print content
+    context.response.close
+  }
+end
+

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -29,14 +29,13 @@ module Amber
           context = create_context(request)
           route = Route.new("GET",
             "/#{action}",
-            build_handler(action, context),
+            build_halt_handler(action, context),
             action,
             :web,
             "",
             "FakeController")
 
           result = route.call(context)
-
           context.response.status_code.should eq 800
         end
       end
@@ -50,7 +49,7 @@ class FakeController < Amber::Controller::Base
   end
 
   def show
-    "Action show result"
+    puts "Action show result"
   end
 
   def halt_lifecycle
@@ -58,7 +57,8 @@ class FakeController < Amber::Controller::Base
   end
 
   def halt_request
-    "Should not be in request"
+    raise "Should not run!"
+    puts "Should not be in request"
   end
 end
 
@@ -68,7 +68,6 @@ def build_handler(action, context)
     controller.run_before_filter(:all)
     controller.run_before_filter(action)
     content = controller.show
-    puts context.response.status_code
     controller.run_after_filter(action)
     controller.run_after_filter(:all)
     context.response.print content
@@ -82,11 +81,9 @@ def build_halt_handler(action, context)
     controller.run_before_filter(:all)
     controller.run_before_filter(action)
     content = controller.halt_request
-    puts context.response.status_code
     controller.run_after_filter(action)
     controller.run_after_filter(:all)
     context.response.print content
     context.response.close
   }
 end
-

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -69,7 +69,8 @@ module Amber
           request = HTTP::Request.new("GET", "/hello/world")
 
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-            "hey world"
+              context.response.print "hey world"
+              context.response.close
           }
 
           route = Route.new("GET", "/hello/world", handler)
@@ -98,7 +99,8 @@ module Amber
         it "register a GET route" do
           router = Router.new
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-            "hey world"
+              context.response.print "hey world"
+              context.response.close
           }
 
           route = Route.new("GET", "/some/joe", handler)
@@ -111,7 +113,8 @@ module Amber
         it "raises Amber::Exceptions::DuplicateRouteError on duplicate" do
           router = Router.new
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-            "hey world"
+              context.response.print "hey world"
+              context.response.close
           }
           route = Route.new("GET", "/some/joe", handler)
 
@@ -126,7 +129,10 @@ module Amber
       describe "#all" do
         it "gets all routes defined" do
           router = Router.new
-          handler = ->(context : HTTP::Server::Context, action : Symbol) { "hey" }
+          handler = ->(context : HTTP::Server::Context, action : Symbol) {
+              context.response.print "hey world"
+              context.response.close
+          }
           routes = [Route.new("GET", "/", handler),
                     Route.new("GET", "/a", handler),
                     Route.new("DELETE", "/b", handler),

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -69,8 +69,8 @@ module Amber
           request = HTTP::Request.new("GET", "/hello/world")
 
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-              context.response.print "hey world"
-              context.response.close
+            context.response.print "hey world"
+            context.response.close
           }
 
           route = Route.new("GET", "/hello/world", handler)
@@ -99,8 +99,8 @@ module Amber
         it "register a GET route" do
           router = Router.new
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-              context.response.print "hey world"
-              context.response.close
+            context.response.print "hey world"
+            context.response.close
           }
 
           route = Route.new("GET", "/some/joe", handler)
@@ -113,8 +113,8 @@ module Amber
         it "raises Amber::Exceptions::DuplicateRouteError on duplicate" do
           router = Router.new
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-              context.response.print "hey world"
-              context.response.close
+            context.response.print "hey world"
+            context.response.close
           }
           route = Route.new("GET", "/some/joe", handler)
 
@@ -130,8 +130,8 @@ module Amber
         it "gets all routes defined" do
           router = Router.new
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
-              context.response.print "hey world"
-              context.response.close
+            context.response.print "hey world"
+            context.response.close
           }
           routes = [Route.new("GET", "/", handler),
                     Route.new("GET", "/a", handler),

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -62,9 +62,9 @@ module Amber
       @pubsub_adapter = WebSockets::Adapters::MemoryAdapter
       @redis_url = "redis://localhost:6379"
       @session = {
-        :key       => "session_id",
+        :key => "session_id",
         # store can be [:signed_cookie, :encrypted_cookie, :redis]
-        :store     => :signed_cookie, 
+        :store     => :signed_cookie,
         :expires   => 0,
         :secret    => secret,
         :redis_url => "redis://localhost:6379",

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -32,5 +32,12 @@ module Amber::Controller
     def session
       context.session
     end
+
+    def halt(status_code = 200, output = "")
+      context.response.headers["Content-Type"] = "text/plain"
+      context.response.status_code = status_code
+      context.response.print output
+      context.response.close
+    end
   end
 end

--- a/src/amber/controller/filters.cr
+++ b/src/amber/controller/filters.cr
@@ -9,8 +9,8 @@ module Amber::Controller
        def run_before_filter(action)
         if self.responds_to? :before_filters
           self.before_filters
-          @filters.run(:before, action)
           @filters.run(:before, :all)
+          @filters.run(:before, action)
         end
       end
 

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -16,7 +16,8 @@ module Amber::DSL
         content = controller.{{ action.id }}
         controller.run_after_filter(action)
         controller.run_after_filter(:all)
-        content
+        context.response.print(content)
+        context.response.close
       }
       %verb = {{verb.upcase.id.stringify}}
       %route = Amber::Route.new(%verb, {{resource}}, %handler, {{action}}, valve, scope, "{{controller.id}}")

--- a/src/amber/exceptions/exceptions.cr
+++ b/src/amber/exceptions/exceptions.cr
@@ -5,8 +5,9 @@ module Amber
 
       def set_response(response)
         response.headers["Content-Type"] = "text/plain"
-        response.print message
         response.status_code = status_code
+        response.print message
+        response.close
       end
     end
 

--- a/src/amber/router/cookies.cr
+++ b/src/amber/router/cookies.cr
@@ -229,7 +229,7 @@ module Amber::Router
 
       private def verify(message)
         @verifier.verify(message)
-      rescue e # TODO: This should probably actually raise the exception instead of rescueing from it. 
+      rescue e # TODO: This should probably actually raise the exception instead of rescueing from it.
         ""
       end
     end
@@ -270,7 +270,7 @@ module Amber::Router
 
       private def verify_and_decrypt(encrypted_message)
         String.new(@encryptor.verify_and_decrypt(encrypted_message))
-      rescue e # TODO: This should probably actually raise the exception instead of rescueing from it. 
+      rescue e # TODO: This should probably actually raise the exception instead of rescueing from it.
         ""
       end
     end

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -18,7 +18,7 @@ module Amber
         if context.websocket?
           context.process_websocket_request
         else
-          @drain[context.valve].call(context) if @drain[context.valve]
+          @drain[context.valve].not_nil!.call(context)
         end
       rescue e : Amber::Exceptions::Base
         e.set_response(context.response)
@@ -40,8 +40,8 @@ module Amber
           @drain[valve] ||= build_pipeline(
             pipeline[valve],
             ->(context : HTTP::Server::Context) {
-              context.response.print(context.process_request)
-            })
+              context.process_request
+           })
         end
       end
 

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -41,7 +41,7 @@ module Amber
             pipeline[valve],
             ->(context : HTTP::Server::Context) {
               context.process_request
-           })
+            })
         end
       end
 

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -4,11 +4,23 @@ module Amber
 
     def initialize(@verb : String,
                    @resource : String,
-                   @handler : Proc(HTTP::Server::Context, Symbol, String),
+                   @handler : Proc(HTTP::Server::Context, Symbol, Bool | Nil),
                    @action : Symbol = :index,
                    @valve : Symbol = :web,
                    @scope : String = "",
                    @controller : String = "")
+    end
+
+    def call(context)
+      handler.call(context, action)
+    end
+
+    def trail
+      "#{verb.to_s.downcase}#{scope}#{resource}"
+    end
+
+    def trail_head
+      "head#{scope}#{resource}"
     end
 
     def to_json
@@ -22,18 +34,6 @@ module Amber
           json.field "resource", resource
         end
       end
-    end
-
-    def trail
-      "#{verb.to_s.downcase}#{scope}#{resource}"
-    end
-
-    def trail_head
-      "head#{scope}#{resource}"
-    end
-
-    def call(context)
-      handler.call(context, action)
     end
   end
 end

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -13,6 +13,8 @@ module Amber
 
     def call(context)
       handler.call(context, action)
+    rescue ex : Amber::Exceptions::HaltRequest
+      ex.set_response(context.response)
     end
 
     def trail

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -13,8 +13,6 @@ module Amber
 
     def call(context)
       handler.call(context, action)
-    rescue ex : Amber::Exceptions::HaltRequest
-      ex.set_response(context.response)
     end
 
     def trail


### PR DESCRIPTION
## Add short circuit to halt request lifecycle

### Applicable Issues

Issue https://github.com/amber-crystal/amber/issues/156

### Requirements

> As a developer, If redirect_to or render is called in before_action, the action should not run, but it does run currently. Redirect_to or render in action is fine since we can simply return.
However, if they can cancel the action in before_action, before_action can be more useful and easy to do lots of things like authentication.

### Description of the Change

- Adds a halt method to short circuit the request lifecycle causing the response to be written and close at the moment this method is called. Concept thanks to Kemal halt @sdogruyol https://github.com/kemalcr/kemal/blob/0b4856b7417592743a27fc3e30867fd141395bf6/src/kemal/helpers/macros.cr
- Halt method takes two arguments a status_code and an output.
- Controllers actions don't need to return strings
- The response now gets printed within the route handler see change (https://github.com/amber-crystal/amber/compare/ep/halt-request-lifecycle?expand=1#diff-d58c8f9ba048a01c31b2beb56b72840cR43 and https://github.com/amber-crystal/amber/compare/ep/halt-request-lifecycle?expand=1#diff-7ecdd88ee52d1f44596e2e8f5184df65R7)

### Alternate Designs

**Raising an exception**
Generally, the use of exceptions for control flow is an anti-pattern, with notable situation- and language-specific cough exceptions cough.

As a quick summary for why, generally, it's an anti-pattern:

- Exceptions are, in essence, sophisticated GOTO statements
- Programming with exceptions, therefore, leads to more difficult to read, and understand code
- Most languages have existing control structures designed to solve your problems without the use of exceptions
- Arguments for efficiency tend to be moot for modern compilers, which tend to optimize with the assumption that exceptions are not used for control flow.

Raising an exception involves allocating memory, and executing an exception handler is generally slow. (https://crystal-lang.org/docs/syntax_and_semantics/exception_handling.html bottom section) 

**Catch and Throw**
Unfortunately this is unsupported and difficult to implement according to @straight-shoota

### Why Should This Be In Core?

Halting a request is a convenient way to not process more than necessary and allows for more request lifecycle control flow/options.

### Benefits

Allows to skip processing code when not necessary.

```crystal
class FakeController < Amber::Controller::Base
  before_action do
    only :halt_request { halt_lifecycle }
  end

  def show
    "Action show result"
  end

  def halt_lifecycle
    redirect_to "/something"
    halt(status_code = 302) # for redirects to work
  end

  def halt_request
    "Should not be in request"
  end
end
```






