### PR TITLE
fix duplicate filter call

### DIFF
--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -11,11 +11,9 @@ module Amber::DSL
     macro route(verb, resource, controller, action)
       %handler = ->(context : HTTP::Server::Context, action : Symbol){
         controller = {{controller.id}}.new(context)
-        controller.run_before_filter(:all)
         controller.run_before_filter(action)
         content = controller.{{ action.id }}
         controller.run_after_filter(action)
-        controller.run_after_filter(:all)
         content
       }
       %verb = {{verb.upcase.id.stringify}}


### PR DESCRIPTION
### Description of the Change

Remove the duplicate filter calls in [src/amber/dsl/router.cr](https://github.com/amber-crystal/amber/blob/0935dee6637552fda2d80c2bcf6c64194c2e993a/src/amber/dsl/router.cr#L11).

There are already `@filters.run(:before, :all)` and `@filters.run(:after, :all)` in [src/amber/controller/filters.cr](https://github.com/amber-crystal/amber/blob/acbba3a5ebc211c0f2cab265171eed26257fa530/src/amber/controller/filters.cr#L9)
so `controller.run_before_filter(:all)` and `controller.run_after_filter(:all)` in [src/amber/dsl/router.cr](https://github.com/amber-crystal/amber/blob/0935dee6637552fda2d80c2bcf6c64194c2e993a/src/amber/dsl/router.cr#L11) are duplicate.

And `self.before_filters` and `self.after_filters` in [src/amber/controller/filters.cr](https://github.com/amber-crystal/amber/blob/acbba3a5ebc211c0f2cab265171eed26257fa530/src/amber/controller/filters.cr#L9) are used for filter registration, so they should not run more than once.

### Why Should This Be In Core?

Since `before_action { only :action }` filter runs twice, `before_action { all }` filter runs four times, and `after_action {all}` filter runs five times currently.

### Benefits

They won't run duplicately.