### PR TITLE
Remove CSRF dead code

### DIFF
--- a/src/amber/router/pipe/csrf.cr
+++ b/src/amber/router/pipe/csrf.cr
@@ -15,9 +15,6 @@ module Amber
           call_next(context)
         else
           raise Amber::Exceptions::Forbidden.new("CSRF check failed.")
-          context.response.status_code = 403
-          context.response.content_type = "text/plain"
-          context.response.print("CSRF check failed.")
         end
       end
 


### PR DESCRIPTION
### Description of the Change

This change is about to remove dead code in CSRF module. All that is actually set [here](https://github.com/amber-crystal/amber/blob/master/src/amber/router/pipe/error.cr#L11-L19).
