### PR TITLE
Fixes Headers for Transfer Encoding Chunked

### DIFF
--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -40,7 +40,10 @@ module Amber
           @drain[valve] ||= build_pipeline(
             pipeline[valve],
             ->(context : HTTP::Server::Context) {
-              context.response.print(context.process_request)
+              content = context.process_request
+              # Ensures it writes cookies to response header
+              context.cookies.write(context.response.headers)
+              context.response.print(content)
             })
         end
       end

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -41,8 +41,13 @@ module Amber
             pipeline[valve],
             ->(context : HTTP::Server::Context) {
               content = context.process_request
-              # Ensures it writes cookies to response header
-              context.cookies.write(context.response.headers)
+              response = context.response
+              if response.version != "HTTP/1.0" && !response.headers.has_key?("Content-Length")
+                context.session.set_session
+                context.cookies.write(context.response.headers)
+              else
+                context.cookies.write(context.response.headers)
+              end
               context.response.print(content)
             })
         end

--- a/src/amber/router/pipe/session.cr
+++ b/src/amber/router/pipe/session.cr
@@ -5,14 +5,9 @@ module Amber
     # be used to maintain data across requests.
     class Session < Base
       def call(context : HTTP::Server::Context)
-        # Session has to be set before it can be use down the pipeline
-        context.session.set_session
-
         call_next(context)
-      ensure
-        if context.session.changed?
-          context.cookies.write(context.response.headers)
-        end
+        # Writes the session to the store 
+        context.session.set_session
       end
     end
   end

--- a/src/amber/router/pipe/session.cr
+++ b/src/amber/router/pipe/session.cr
@@ -5,10 +5,12 @@ module Amber
     # be used to maintain data across requests.
     class Session < Base
       def call(context : HTTP::Server::Context)
-        call_next(context)
+        # Session has to be set before it can be use down the pipeline
+        context.session.set_session
 
+        call_next(context)
+      ensure
         if context.session.changed?
-          context.session.set_session
           context.cookies.write(context.response.headers)
         end
       end

--- a/src/amber/router/pipe/session.cr
+++ b/src/amber/router/pipe/session.cr
@@ -6,8 +6,9 @@ module Amber
     class Session < Base
       def call(context : HTTP::Server::Context)
         call_next(context)
-        # Writes the session to the store 
+        # Writes the session to the store
         context.session.set_session
+        context.cookies.write(context.response.headers)
       end
     end
   end

--- a/src/amber/router/pipe/session.cr
+++ b/src/amber/router/pipe/session.cr
@@ -8,7 +8,6 @@ module Amber
         call_next(context)
         # Writes the session to the store
         context.session.set_session
-        context.cookies.write(context.response.headers)
       end
     end
   end


### PR DESCRIPTION
### Requirements

> Headers are not currently being printed at the end of the response
when transfer encoding is set to chunked.

### Description of the Change

This attempts to correct the issue by ensuring that cookies are written
at the end of the pipeline

- It seems that we cannot use session.changed? since
context.cookies.write(context.response.headers) writes not only the
session but also any other cookies

- context.session.set_session has to be called before call_next(context)
since it prepares the session scope. If done after none of the pipes
down the drain will have a session and no session will be ever set.

![screen shot 2017-08-04 at 3 48 38 pm](https://user-images.githubusercontent.com/1685772/28984528-67eeaa48-792c-11e7-9957-b2617dababc6.png)
