### PR TITLE
Pair/fix chunking - CSRF will work now all the time.

### DIFF
--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -55,10 +55,14 @@ class HTTP::Server::Context
   end
 
   def process_request
-    @content = request_handler.call(self)
+    content = request_handler.call(self)
   end
 
   def valve
     request_handler.valve
+  end
+
+  def finalize_response
+    response.print(content)
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -55,9 +55,7 @@ class HTTP::Server::Context
   end
 
   def process_request
-    content = request_handler.call(self)
-    puts content
-    content
+    @content = request_handler.call(self)
   end
 
   def valve
@@ -65,8 +63,6 @@ class HTTP::Server::Context
   end
 
   def finalize_response
-    puts "inside of finalize"
-    puts content
-    response.print(content)
+    response.print(@content)
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -56,6 +56,8 @@ class HTTP::Server::Context
 
   def process_request
     content = request_handler.call(self)
+    puts content
+    content
   end
 
   def valve
@@ -63,6 +65,8 @@ class HTTP::Server::Context
   end
 
   def finalize_response
+    puts "inside of finalize"
+    puts content
     response.print(content)
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -14,6 +14,7 @@ class HTTP::Server::Context
   setter flash : Amber::Router::Flash::FlashStore?
   setter cookies : Amber::Router::Cookies::Store?
   setter session : Amber::Router::Session::AbstractStore?
+  property content : String?
 
   def initialize(@request : HTTP::Request, @response : HTTP::Server::Response)
     @router = Amber::Router::Router.instance
@@ -54,7 +55,7 @@ class HTTP::Server::Context
   end
 
   def process_request
-    request_handler.call(self)
+    @content = request_handler.call(self)
   end
 
   def valve

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -19,7 +19,7 @@ module Amber
           context.process_websocket_request
         elsif @drain[context.valve]
           @drain[context.valve].call(context)
-          context.response.print(context.content)
+          context.finalize_response
         end
       rescue e : Amber::Exceptions::Base
         e.set_response(context.response)

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -17,8 +17,9 @@ module Amber
         raise Amber::Exceptions::RouteNotFound.new(context.request) if context.invalid_route?
         if context.websocket?
           context.process_websocket_request
-        else
-          @drain[context.valve].call(context) if @drain[context.valve]
+        elsif @drain[context.valve]
+          @drain[context.valve].call(context)
+          context.response.print(context.content)
         end
       rescue e : Amber::Exceptions::Base
         e.set_response(context.response)
@@ -40,7 +41,7 @@ module Amber
           @drain[valve] ||= build_pipeline(
             pipeline[valve],
             ->(context : HTTP::Server::Context) {
-              context.response.print(context.process_request)
+              context.process_request
             })
         end
       end


### PR DESCRIPTION
### Description of the Change

Fixes bug where headers weren't written in for payloads of over 8191 bytes. The trick ended up being writing headers before writing body which ended up closing the IO in chunk-mode.

### Why Should This Be In Core?

It fixes a bug in an existing feature.