### PR TITLE
Halt Request Lifecycle

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -223,7 +223,7 @@ module Amber::Controller
           controller.halt!
           context = controller.context
 
-          context.halt.should eq true
+          context.content.should eq ""
         end
 
         it "set response status code" do

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -4,7 +4,7 @@ module Amber::Controller
   describe Base do
     describe "#cookies" do
       it "responds to cookies" do
-        controller = build_controller("")
+        controller = build_controller
 
         controller.responds_to?(:cookies).should eq true
       end
@@ -12,13 +12,13 @@ module Amber::Controller
 
     describe "#session" do
       it "responds to cookies" do
-        controller = build_controller("")
+        controller = build_controller
 
         controller.responds_to?(:session).should eq true
       end
 
       it "sets a session value" do
-        controller = build_controller("")
+        controller = build_controller
 
         controller.session["name"] = "David"
 
@@ -26,7 +26,7 @@ module Amber::Controller
       end
 
       it "has a session id" do
-        controller = build_controller("")
+        controller = build_controller
 
         controller.session.id.not_nil!.size.should eq 36
       end
@@ -98,7 +98,7 @@ module Amber::Controller
     describe "#before_action" do
       context "registering action filters" do
         it "registers a before action" do
-          controller = build_controller("")
+          controller = build_controller
           controller.before_filters
 
           before_filters = controller.filters[:before]
@@ -107,7 +107,7 @@ module Amber::Controller
         end
 
         it "registers a after action" do
-          controller = build_controller("")
+          controller = build_controller
           controller.after_filters
 
           after_filters = controller.filters[:after]
@@ -118,14 +118,14 @@ module Amber::Controller
 
       context "running filters" do
         it "runs before filters" do
-          controller = build_controller("")
+          controller = build_controller
           controller.run_before_filter(:index)
 
           controller.total.should eq 4
         end
 
         it "runs after filters" do
-          controller = build_controller("")
+          controller = build_controller
           controller.run_after_filter(:index)
 
           controller.total.should eq 2
@@ -147,7 +147,7 @@ module Amber::Controller
 
       context "and does not have a referer" do
         it "raisees an error" do
-          hello_controller = build_controller("")
+          hello_controller = build_controller
 
           expect_raises Exceptions::Controller::Redirect do
             hello_controller.redirect_back
@@ -171,7 +171,7 @@ module Amber::Controller
       context "when redirecting to url or path" do
         ["www.amberio.com", "/world"].each do |location|
           it "sets the location to #{location}" do
-            hello_controller = build_controller("")
+            hello_controller = build_controller
             hello_controller.redirect_to(location, 301)
 
             response = hello_controller.response
@@ -184,7 +184,7 @@ module Amber::Controller
 
       context "with invalid url or path" do
         it "raises redirect error" do
-          hello_controller = build_controller("")
+          hello_controller = build_controller
 
           expect_raises Exceptions::Controller::Redirect do
             hello_controller.redirect_to "saasd"
@@ -194,7 +194,7 @@ module Amber::Controller
 
       context "when redirecting to controller action" do
         it "sets the controller and action" do
-          hello_controller = build_controller("")
+          hello_controller = build_controller
           hello_controller.redirect_to :world, 301
 
           response = hello_controller.response
@@ -204,15 +204,35 @@ module Amber::Controller
         end
       end
 
-      context "when redirector to different controller" do
+      context "when redirecting to different controller" do
         it "sets new controller and action" do
-          hello_controller = build_controller("")
+          hello_controller = build_controller
           hello_controller.redirect_to :hello, :index, 301
 
           response = hello_controller.response
 
           response.headers["Location"].should eq "/hello/index"
           response.status_code.should eq 301
+        end
+      end
+
+      context "#halt!" do
+        it "sets context halt to true" do
+          controller = build_controller
+
+          controller.halt!
+          context = controller.context
+
+          context.halt.should eq true
+        end
+
+        it "set response status code" do
+          controller = build_controller
+
+          controller.halt!(status_code = 900)
+          context = controller.context
+
+          context.response.status_code.should eq 900
         end
       end
     end

--- a/spec/amber/route_spec.cr
+++ b/spec/amber/route_spec.cr
@@ -19,10 +19,10 @@ module Amber
         it "does not execute action" do
           handler = ->(context : HTTP::Server::Context, action : Symbol) {
             controller = FakeController.new(context)
-            controller.run_before_filter(action) unless context.halt
-            content = controller.halt_action unless context.halt
-            controller.run_after_filter(action) unless context.halt
-            content || ""
+            controller.run_before_filter(action) unless context.content
+            content = controller.halt_action unless context.content
+            controller.run_after_filter(action) unless context.content
+            content.to_s
           }
 
           request = HTTP::Request.new("GET", "")
@@ -31,8 +31,7 @@ module Amber
 
           route.call(context).should eq ""
           context.response.status_code.should eq 900
-          context.halt.should eq true
-          context.content.should eq nil
+          context.content.should eq ""
         end
       end
 
@@ -40,10 +39,10 @@ module Amber
         it "halts request execution" do
           new_handler = ->(context : HTTP::Server::Context, action : Symbol) {
             controller = FakeRedirectController.new(context)
-            controller.run_before_filter(action) unless context.halt
-            content = controller.redirect_action unless context.halt
-            controller.run_after_filter(action) unless context.halt
-            content || ""
+            controller.run_before_filter(action) unless context.content
+            content = controller.redirect_action unless context.content
+            controller.run_after_filter(action) unless context.content
+            content.to_s
           }
 
           request = HTTP::Request.new("GET", "/")
@@ -52,8 +51,7 @@ module Amber
 
           route.call(context).should eq ""
           context.response.status_code.should eq 302
-          context.halt.should eq true
-          context.content.should eq nil
+          context.content.should eq "Redirecting to /"
         end
       end
     end

--- a/spec/amber/route_spec.cr
+++ b/spec/amber/route_spec.cr
@@ -13,5 +13,67 @@ module Amber
 
       route.class.should eq Route
     end
+
+    describe "#call" do
+      context "before action" do
+        it "does not execute action" do
+          handler = ->(context : HTTP::Server::Context, action : Symbol) {
+            controller = FakeController.new(context)
+            controller.run_before_filter(action) unless context.halt
+            content = controller.halt_action unless context.halt
+            controller.run_after_filter(action) unless context.halt
+            content || ""
+          }
+
+          request = HTTP::Request.new("GET", "")
+          context = create_context(request)
+          route = Route.new("GET", "", handler, :halt_action)
+
+          route.call(context).should eq ""
+          context.response.status_code.should eq 900
+          context.halt.should eq true
+          context.content.should eq nil
+        end
+      end
+
+      context "when redirecting" do
+        it "halts request execution" do
+          new_handler = ->(context : HTTP::Server::Context, action : Symbol) {
+            controller = FakeRedirectController.new(context)
+            controller.run_before_filter(action) unless context.halt
+            content = controller.redirect_action unless context.halt
+            controller.run_after_filter(action) unless context.halt
+            content || ""
+          }
+
+          request = HTTP::Request.new("GET", "/")
+          context = create_context(request)
+          route = Route.new("GET", "", new_handler, :redirect_action)
+
+          route.call(context).should eq ""
+          context.response.status_code.should eq 302
+          context.halt.should eq true
+          context.content.should eq nil
+        end
+      end
+    end
+  end
+end
+
+class FakeController < Amber::Controller::Base
+  before_action do
+    only :halt_action { halt!(900) }
+  end
+
+  def halt_action
+    raise "Should not reach this action"
+    ""
+  end
+end
+
+class FakeRedirectController < Amber::Controller::Base
+  def redirect_action
+    redirect_to "/"
+    ""
   end
 end

--- a/spec/support/helpers.cr
+++ b/spec/support/helpers.cr
@@ -41,7 +41,7 @@ def create_context(request)
   HTTP::Server::Context.new(request, response)
 end
 
-def build_controller(referer)
+def build_controller(referer = "")
   request = HTTP::Request.new("GET", "/")
   request.headers.add("Referer", referer)
   context = create_context(request)

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -34,6 +34,7 @@ module Amber::Controller
     end
 
     def halt!(status_code : Int32 = 200, content = "")
+      response.headers["Content-Type"] = "text/plain"
       response.status_code = status_code
       response.print content
       response.close

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -36,9 +36,7 @@ module Amber::Controller
     def halt!(status_code : Int32 = 200, content = "")
       response.headers["Content-Type"] = "text/plain"
       response.status_code = status_code
-      response.print content
-      response.close
-      context.halt = true
+      context.content = content
     end
   end
 end

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -32,5 +32,12 @@ module Amber::Controller
     def session
       context.session
     end
+
+    def halt!(status_code : Int32 = 200, content = "")
+      response.status_code = status_code
+      response.print content
+      response.close
+      context.halt = true
+    end
   end
 end

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -1,28 +1,23 @@
 module Amber::Controller
   # This class writes the redirect URL to the response headers and parses params.
   class LocationRedirect
-    getter location, status, flash, query_params
+    getter location, status, query_params
 
     def initialize(@location : String,
                    @status = 302,
                    @query_params : Hash(String, String)? = nil)
-      # Todo add flash as a parameter for redirect
-      # Todo add default route scope for given controller action
       raise_redirect_error(location) if location.empty?
     end
 
     def redirect(for response)
-      return set_location(response, location, status, query_params) if location.url?
-      return set_location(response, location, status, query_params) if location.chars.first == '/'
-      raise_redirect_error(location)
+      raise_redirect_error(location) unless location.url? || location.chars.first == '/'
+      set_location(response, location, status, query_params)
     end
 
     private def set_location(response, location, status = 302, query_params : _ = nil)
       url_path = encode_query_string(location, query_params)
       response.headers.add "Location", url_path
       response.status_code = status
-
-      "Redirecting to #{url_path}"
     end
 
     def encode_query_string(location, query_params)
@@ -38,21 +33,25 @@ module Amber::Controller
   module RedirectFactory
     def redirect_to(location : String, *args)
       LocationRedirect.new(location, *args).redirect(response)
+      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
 
     # Redirects to the specified controller, action
     def redirect_to(controller : Symbol, action : Symbol, *args)
       LocationRedirect.new("/#{controller}/#{action}", *args).redirect(response)
+      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
 
     # Redirects within the same controller
     def redirect_to(action : Symbol, *args)
       controller = self.class.to_s.chomp("Controller").downcase
       LocationRedirect.new("/#{controller}/#{action}", *args).redirect(response)
+      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
 
     def redirect_back(*args)
       LocationRedirect.new(request.headers["Referer"]).redirect(response)
+      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
   end
 end

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -12,9 +12,9 @@ module Amber::DSL
       %handler = ->(context : HTTP::Server::Context, action : Symbol){
         controller = {{controller.id}}.new(context)
         controller.run_before_filter(action) unless context.halt
-        content = controller.{{ action.id }} unless context.halt
+        content = context.halt ? nil : controller.{{ action.id }}
         controller.run_after_filter(action) unless context.halt
-        content || ""
+        content.to_s
       }
       %verb = {{verb.upcase.id.stringify}}
       %route = Amber::Route.new(

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -11,13 +11,15 @@ module Amber::DSL
     macro route(verb, resource, controller, action)
       %handler = ->(context : HTTP::Server::Context, action : Symbol){
         controller = {{controller.id}}.new(context)
-        controller.run_before_filter(action)
-        content = controller.{{ action.id }}
-        controller.run_after_filter(action)
-        content
+        controller.run_before_filter(action) unless context.halt
+        content = controller.{{ action.id }} unless context.halt
+        controller.run_after_filter(action) unless context.halt
+        content || ""
       }
       %verb = {{verb.upcase.id.stringify}}
-      %route = Amber::Route.new(%verb, {{resource}}, %handler, {{action}}, valve, scope, "{{controller.id}}")
+      %route = Amber::Route.new(
+        %verb, {{resource}}, %handler, {{action}}, valve, scope, "{{controller.id}}"
+      )
 
       router.add(%route)
     end

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -11,9 +11,9 @@ module Amber::DSL
     macro route(verb, resource, controller, action)
       %handler = ->(context : HTTP::Server::Context, action : Symbol){
         controller = {{controller.id}}.new(context)
-        controller.run_before_filter(action) unless context.halt
-        content = context.halt ? nil : controller.{{ action.id }}
-        controller.run_after_filter(action) unless context.halt
+        controller.run_before_filter(action) unless context.content
+        content = controller.{{ action.id }} unless context.content
+        controller.run_after_filter(action) unless context.content
         content.to_s
       }
       %verb = {{verb.upcase.id.stringify}}

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -15,6 +15,7 @@ class HTTP::Server::Context
   setter cookies : Amber::Router::Cookies::Store?
   setter session : Amber::Router::Session::AbstractStore?
   property content : String?
+  property halt : Bool = false
 
   def initialize(@request : HTTP::Request, @response : HTTP::Server::Response)
     @router = Amber::Router::Router.instance

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -15,7 +15,6 @@ class HTTP::Server::Context
   setter cookies : Amber::Router::Cookies::Store?
   setter session : Amber::Router::Session::AbstractStore?
   property content : String?
-  property halt : Bool = false
 
   def initialize(@request : HTTP::Request, @response : HTTP::Server::Response)
     @router = Amber::Router::Router.instance


### PR DESCRIPTION
Issue: https://github.com/amber-crystal/amber/issues/156

### Requirements
>If redirect_to or render is called in before_action, the action
should not run, but it does run currently. redirect_to or render
in action is fine since we can simply return. However, if they
can cancel the action in before_action, before_action can be
more useful and easy to do lots of things like authentication.

- Exits request action lifecycle by returning false from anywhere
in the controller including redirect_to, before/after filters and
actions.

- As soon the request Lifecycle is halted it will begin to unfold
the response.

- Alternatively you can use `return halt(status_code, content)` to
halt the request, this method sets status_code and content for the
response, and returns false.

### Description of the Change

- Introduces *halt!* controller method which cancels a request lifecycle
- *redirect_to* now halts the request

### Alternate Designs

```crystal

class FakeController < Amber::Controller::Base
  before_action do
    only :halt_action { halt!(900) }
  end

  def halt_action
    raise "Should not reach this action"
    ""
  end

end

class FakeRedirectController < Amber::Controller::Base

  def redirect_action
    redirect_to "/"
    ""
  end
end
```
### Benefits

Avoids extra processing when calling *halt!*