### PR TITLE
Adds Flash to Current Redirect Implementation

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -160,7 +160,7 @@ module Amber::Controller
       context "with url params" do
         it "sets the url params to path" do
           hello_controller = build_controller("/world")
-          hello_controller.redirect_to(:world, 302, {"hello" => "world"})
+          hello_controller.redirect_to(:world, status: 302, params: {"hello" => "world"})
 
           response = hello_controller.response
 
@@ -168,11 +168,33 @@ module Amber::Controller
         end
       end
 
+      context "whith flash" do
+        it "sets the flash scope from Hash(Symbol, String)" do
+          controller = build_controller("")
+          query = {} of String => String
+          controller.redirect_to(:world, status: 302, flash: {"notice" => "Success!"})
+
+          flash = controller.flash
+
+          flash["notice"].should eq "Success!"
+        end
+
+        it "sets the flash scope from Hash(String, String)" do
+          controller = build_controller("")
+          query = {} of String => String
+          controller.redirect_to(:world, status: 302, flash: {"notice" => "Success!"})
+
+          flash = controller.flash
+
+          flash["notice"].should eq "Success!"
+        end
+      end
+
       context "when redirecting to url or path" do
         ["www.amberio.com", "/world"].each do |location|
           it "sets the location to #{location}" do
             hello_controller = build_controller
-            hello_controller.redirect_to(location, 301)
+            hello_controller.redirect_to(location, status: 301)
 
             response = hello_controller.response
 
@@ -182,20 +204,10 @@ module Amber::Controller
         end
       end
 
-      context "with invalid url or path" do
-        it "raises redirect error" do
-          hello_controller = build_controller
-
-          expect_raises Exceptions::Controller::Redirect do
-            hello_controller.redirect_to "saasd"
-          end
-        end
-      end
-
       context "when redirecting to controller action" do
         it "sets the controller and action" do
           hello_controller = build_controller
-          hello_controller.redirect_to :world, 301
+          hello_controller.redirect_to :world, status: 301
 
           response = hello_controller.response
 
@@ -207,7 +219,7 @@ module Amber::Controller
       context "when redirecting to different controller" do
         it "sets new controller and action" do
           hello_controller = build_controller
-          hello_controller.redirect_to :hello, :index, 301
+          hello_controller.redirect_to :hello, :index, status: 301
 
           response = hello_controller.response
 

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -38,5 +38,9 @@ module Amber::Controller
       response.status_code = status_code
       context.content = content
     end
+
+    def controller_name
+      self.class.name.downcase.gsub("controller", "")
+    end
   end
 end

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -14,7 +14,7 @@ module Amber::Controller
 
     def redirect(for context)
       response = context.response
-      context.flash.merge!(flash) if flash
+      context.flash.merge!(flash.not_nil!) if !flash.nil?
       raise_redirect_error(location) unless location.url? || location.chars.first == '/'
       set_location(response, location, status, params)
     end

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -14,7 +14,7 @@ module Amber::Controller
 
     def redirect(for context)
       response = context.response
-      context.flash.merge!(flash)
+      context.flash.merge!(flash) if flash
       raise_redirect_error(location) unless location.url? || location.chars.first == '/'
       set_location(response, location, status, params)
     end

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -1,27 +1,30 @@
 module Amber::Controller
   # This class writes the redirect URL to the response headers and parses params.
   class LocationRedirect
-    getter location, status, query_params
+    getter location, status, params
 
-    def initialize(@location : String,
-                   @status = 302,
-                   @query_params : Hash(String, String)? = nil)
+    @location : String
+    @status : Int32 = 302
+    @params : Hash(String, String)? = nil
+    @flash : Hash(String, String)? = nil
+
+    def initialize(@location, @status = 302, @params = nil, @flash = nil)
       raise_redirect_error(location) if location.empty?
     end
 
     def redirect(for response)
       raise_redirect_error(location) unless location.url? || location.chars.first == '/'
-      set_location(response, location, status, query_params)
+      set_location(response, location, status, params)
     end
 
-    private def set_location(response, location, status = 302, query_params : _ = nil)
-      url_path = encode_query_string(location, query_params)
+    private def set_location(response, location, status = 302, params : _ = nil)
+      url_path = encode_query_string(location, params)
       response.headers.add "Location", url_path
       response.status_code = status
     end
 
-    def encode_query_string(location, query_params)
-      return location + "?" + HTTP::Params.encode(query_params).to_s if query_params
+    def encode_query_string(location, params)
+      return location + "?" + HTTP::Params.encode(params).to_s if params
       location
     end
 
@@ -31,26 +34,29 @@ module Amber::Controller
   end
 
   module RedirectFactory
-    def redirect_to(location : String, *args)
-      LocationRedirect.new(location, *args).redirect(response)
+    def redirect_to(location : String, **args)
+      flash.merge!(args[:flash]?)
+      LocationRedirect.new(location, **args).redirect(response)
       halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
 
     # Redirects to the specified controller, action
-    def redirect_to(controller : Symbol, action : Symbol, *args)
-      LocationRedirect.new("/#{controller}/#{action}", *args).redirect(response)
+    def redirect_to(controller : Symbol, action : Symbol, **args)
+      flash.merge!(args[:flash]?)
+      LocationRedirect.new("/#{controller}/#{action}", **args).redirect(response)
       halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
 
     # Redirects within the same controller
-    def redirect_to(action : Symbol, *args)
-      controller = self.class.to_s.chomp("Controller").downcase
-      LocationRedirect.new("/#{controller}/#{action}", *args).redirect(response)
+    def redirect_to(action : Symbol, **args)
+      flash.merge!(args[:flash]?)
+      LocationRedirect.new("/#{controller_name}/#{action}", **args).redirect(response)
       halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
 
-    def redirect_back(*args)
-      LocationRedirect.new(request.headers["Referer"]).redirect(response)
+    def redirect_back(**args)
+      flash.merge!(args[:flash]?)
+      LocationRedirect.new(request.headers["Referer"], status: 302).redirect(response)
       halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
     end
   end

--- a/src/amber/router/pipe/flash.cr
+++ b/src/amber/router/pipe/flash.cr
@@ -106,11 +106,9 @@ module Amber
           self
         end
 
-        def merge!(other : Hash(String, String)?)
-          if !other.nil?
-            other.each do |k, v|
-              @flashes[k.to_s] = v
-            end
+        def merge!(other : Hash(String, String))
+          other.each do |k, v|
+            @flashes[k.to_s] = v
           end
           self
         end

--- a/src/amber/router/pipe/flash.cr
+++ b/src/amber/router/pipe/flash.cr
@@ -106,6 +106,15 @@ module Amber
           self
         end
 
+        def merge!(other : Hash(String, String)?)
+          if !other.nil?
+            other.each do |k, v|
+              @flashes[k.to_s] = v
+            end
+          end
+          self
+        end
+
         def to_hash
           @flashes.dup
         end


### PR DESCRIPTION
## Adds Flash to Current Redirect Implementation

**Issue:** https://github.com/amber-crystal/amber/issues/76

* This adds flash to the redirect_to method
* Arguments should be passed as named params
* status, params and flash as optional arguments
* Adds `controller_name` method to controller
* Adds `merge!` to **FlashStore** take a `Hash(String, String)?` as an argument
 
```crystal
redirect_to(:world, status: 302, flash: {"notice" => "Success!"})
redirect_to(:action, status: 302, params: { "some" => "value"}, flash: {"notice" => "Success!"})
redirect_to(:controller, :action, status: 302, params: { "some" => "value"}, flash: {"notice" => "Success!"})
```