### PR TITLE
Fixes Redirect When Controller Action is passed

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -10,6 +10,20 @@ module Amber::Controller
       end
     end
 
+    describe "#redirect_to" do
+      it "responds to redirect_to" do
+        controller = build_controller
+        controller.responds_to?(:redirect_to).should eq true
+      end
+    end
+
+    describe "#redirect_back" do
+      it "responds to redirect_back" do
+        controller = build_controller
+        controller.responds_to?(:redirect_back).should eq true
+      end
+    end
+
     describe "#session" do
       it "responds to cookies" do
         controller = build_controller
@@ -134,7 +148,7 @@ module Amber::Controller
     end
 
     describe "#redirect_back" do
-      context "and has a valid referer" do
+      context "and has a valid referrer" do
         it "sets the correct response headers" do
           hello_controller = build_controller("/world")
 
@@ -145,106 +159,13 @@ module Amber::Controller
         end
       end
 
-      context "and does not have a referer" do
+      context "and does not have a referrer" do
         it "raisees an error" do
           hello_controller = build_controller
 
           expect_raises Exceptions::Controller::Redirect do
             hello_controller.redirect_back
           end
-        end
-      end
-    end
-
-    describe "#redirect_to" do
-      context "with url params" do
-        it "sets the url params to path" do
-          hello_controller = build_controller("/world")
-          hello_controller.redirect_to(:world, status: 302, params: {"hello" => "world"})
-
-          response = hello_controller.response
-
-          response.headers["Location"].should eq "/hello/world?hello=world"
-        end
-      end
-
-      context "whith flash" do
-        it "sets the flash scope from Hash(Symbol, String)" do
-          controller = build_controller("")
-          query = {} of String => String
-          controller.redirect_to(:world, status: 302, flash: {"notice" => "Success!"})
-
-          flash = controller.flash
-
-          flash["notice"].should eq "Success!"
-        end
-
-        it "sets the flash scope from Hash(String, String)" do
-          controller = build_controller("")
-          query = {} of String => String
-          controller.redirect_to(:world, status: 302, flash: {"notice" => "Success!"})
-
-          flash = controller.flash
-
-          flash["notice"].should eq "Success!"
-        end
-      end
-
-      context "when redirecting to url or path" do
-        ["www.amberio.com", "/world"].each do |location|
-          it "sets the location to #{location}" do
-            hello_controller = build_controller
-            hello_controller.redirect_to(location, status: 301)
-
-            response = hello_controller.response
-
-            response.headers["Location"].should eq location
-            response.status_code.should eq 301
-          end
-        end
-      end
-
-      context "when redirecting to controller action" do
-        it "sets the controller and action" do
-          hello_controller = build_controller
-          hello_controller.redirect_to :world, status: 301
-
-          response = hello_controller.response
-
-          response.headers["Location"].should eq "/hello/world"
-          response.status_code.should eq 301
-        end
-      end
-
-      context "when redirecting to different controller" do
-        it "sets new controller and action" do
-          hello_controller = build_controller
-          hello_controller.redirect_to :hello, :index, status: 301
-
-          response = hello_controller.response
-
-          response.headers["Location"].should eq "/hello/index"
-          response.status_code.should eq 301
-        end
-      end
-
-      context "#halt!" do
-        it "sets context halt to true" do
-          controller = build_controller
-
-          controller.halt!
-          context = controller.context
-
-          context.content.should eq ""
-        end
-
-        it "set response status code" do
-          controller = build_controller
-
-          controller.halt!(status_code = 900)
-          context = controller.context
-
-          context.response.status_code.should eq 900
         end
       end
     end

--- a/spec/amber/controller/redirect_spec.cr
+++ b/spec/amber/controller/redirect_spec.cr
@@ -1,0 +1,112 @@
+require "../../../spec_helper"
+
+module Amber::Controller
+  describe Redirector do
+    describe "#redirect" do
+      it "redirects to location" do
+        controller = build_controller
+        redirector = Redirector.new("/some_path")
+
+        redirector.redirect(controller)
+
+        controller.response.headers["location"].should eq "/some_path"
+        controller.response.status_code.should eq 302
+        controller.context.content.nil?.should eq false
+      end
+
+      it "raises Exception::Controller::Redirect on invalid location" do
+        controller = build_controller
+
+        expect_raises Exceptions::Controller::Redirect do
+          redirector = Redirector.new("", params: {"user_id" => "123"})
+        end
+      end
+
+      context "with params" do
+        it "redirect to location and adds params to url" do
+          controller = build_controller
+          redirector = Redirector.new("/some_path", params: {"user_id" => "123"})
+
+          redirector.redirect(controller)
+
+          controller.response.headers["location"].should eq "/some_path?user_id=123"
+          controller.response.status_code.should eq 302
+          controller.context.content.nil?.should eq false
+        end
+      end
+
+      context "with flash" do
+        it "redirects to location and adds flash" do
+          controller = build_controller
+          redirector = Redirector.new("/some_path", flash: {"success" => "Record saved!"})
+
+          flash = controller.flash
+          redirector.redirect(controller)
+
+          controller.response.headers["location"].should eq "/some_path"
+          flash["success"].should eq "Record saved!"
+          controller.response.status_code.should eq 302
+          controller.context.content.nil?.should eq false
+        end
+      end
+
+      context "with a different status code" do
+        it "redirects to location and sets a status code" do
+          controller = build_controller
+          redirector = Redirector.new("/some_path", status = 301)
+
+          flash = controller.flash
+          redirector.redirect(controller)
+
+          controller.response.headers["location"].should eq "/some_path"
+          controller.response.status_code.should eq 301
+          controller.context.content.nil?.should eq false
+        end
+      end
+    end
+
+    describe ".from_controller_action" do
+      Spec.before_each do
+      end
+
+      it "redirects to correct location for given controller action" do
+        router = Amber::Router::Router.instance
+        router.draw :web do
+          get "/fake", HelloController, :index
+          get "/fake/:id", HelloController, :show
+          put "/hello/:id", HelloController, :update
+        end
+        controller = build_controller
+        redirector = Redirector.from_controller_action("hello", :show, params: {"id" => "11"})
+
+        redirector.redirect(controller)
+
+        controller.response.headers["location"].should eq "/fake/11"
+        controller.response.status_code.should eq 302
+        controller.context.content.nil?.should eq false
+      end
+    end
+    describe "#redirect_back" do
+      context "and has a valid referer" do
+        it "sets the correct response headers" do
+          hello_controller = build_controller("/world")
+
+          hello_controller.redirect_back
+          response = hello_controller.response
+
+          response.headers["Location"].should eq "/world"
+        end
+      end
+
+      context "and does not have a referer" do
+        it "raisees an error" do
+          hello_controller = build_controller
+
+          expect_raises Exceptions::Controller::Redirect do
+            hello_controller.redirect_back
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -14,7 +14,7 @@ module Amber
       route.class.should eq Route
     end
 
-    describe "#parse_params" do
+    describe "#substitute_keys)in_path" do
       it "parses route resource params" do
         handler = ->(context : HTTP::Server::Context) {}
         params = {"id" => "123", "name" => "John"}
@@ -27,6 +27,68 @@ module Amber
 
         empty_hash = {} of String => String
         route.substitute_keys_in_path(params).should eq({"/fake/action/123/John", empty_hash})
+      end
+    end
+
+    describe "#match?" do
+      it "matches by controller and action" do
+        handler = ->(context : HTTP::Server::Context) {}
+        route = Route.new("GET",
+          "/fake/action/:id/:name",
+          handler,
+          :action,
+          :web,
+          "", "FakeController")
+
+        route.match?("fake", :action).should eq true
+      end
+
+      it "does not match with invalid controller" do
+        handler = ->(context : HTTP::Server::Context) {}
+        route = Route.new("GET",
+          "/fake/action/:id/:name",
+          handler,
+          :action,
+          :web,
+          "", "FakeController")
+
+        route.match?("invalid", :action).should eq false
+      end
+
+      it "does not match with nil controller" do
+        handler = ->(context : HTTP::Server::Context) {}
+        route = Route.new("GET",
+          "/fake/action/:id/:name",
+          handler,
+          :action,
+          :web,
+          "", "FakeController")
+
+        route.match?(nil, :action).should eq false
+      end
+
+      it "does not match with nil action" do
+        handler = ->(context : HTTP::Server::Context) {}
+        route = Route.new("GET",
+          "/fake/action/:id/:name",
+          handler,
+          :action,
+          :web,
+          "", "FakeController")
+
+        route.match?("fake", nil).should eq false
+      end
+
+      it "does not match with invalid controller" do
+        handler = ->(context : HTTP::Server::Context) {}
+        route = Route.new("GET",
+          "/fake/action/:id/:name",
+          handler,
+          :action,
+          :web,
+          "", "FakeController")
+
+        route.match?("false", :invalid).should eq false
       end
     end
 

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -17,7 +17,7 @@ module Amber
     describe "#parse_params" do
       it "parses route resource params" do
         handler = ->(context : HTTP::Server::Context) {}
-        params = {"id" => 123, "name" => "John"}
+        params = {"id" => "123", "name" => "John"}
         route = Route.new("GET",
           "/fake/action/:id/:name",
           handler,
@@ -26,7 +26,7 @@ module Amber
           "", "FakeController")
 
         empty_hash = {} of String => String
-        route.parse_params(params).should eq({"/fake/action/123/John", empty_hash})
+        route.substitute_keys_in_path(params).should eq({"/fake/action/123/John", empty_hash})
       end
     end
 

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -1,4 +1,4 @@
-require "./../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   describe Route do
@@ -12,6 +12,22 @@ module Amber
       route = Route.new("GET", "/", handler)
 
       route.class.should eq Route
+    end
+
+    describe "#parse_params" do
+      it "parses route resource params" do
+        handler = ->(context : HTTP::Server::Context) {}
+        params = {"id" => 123, "name" => "John"}
+        route = Route.new("GET",
+          "/fake/action/:id/:name",
+          handler,
+          :action,
+          :web,
+          "", "FakeController")
+
+        empty_hash = {} of String => String
+        route.parse_params(params).should eq({"/fake/action/123/John", empty_hash})
+      end
     end
 
     describe "#call" do

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -123,6 +123,19 @@ module Amber
         end
       end
 
+      describe "#match_by_controller_action" do
+        it "matches route by controller and action" do
+          router = Router.new
+          handler = ->(context : HTTP::Server::Context) {}
+          routeA = Route.new("GET", "/fake", handler, :index, :web, "", "FakeController")
+          route = Route.new("GET", "/fake/route", handler, :route, :web, "", "FakeController")
+          router.add routeA
+          router.add route
+
+          router.match_by_controller_action("fake", :route).should eq route
+        end
+      end
+
       describe "#all" do
         it "gets all routes defined" do
           router = Router.new

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -4,7 +4,7 @@ require "./**"
 module Amber::Controller
   class Base
     include Render
-    include RedirectFactory
+    include RedirectMethods
     include Callbacks
     include Helpers::Tag
 

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -28,6 +28,7 @@ module Amber::Controller
     def self.from_controller_action(controller : String, action : Symbol, **options)
       router = Amber::Router::Router.instance
       route = router.match_by_controller_action(controller, action)
+      raise Exceptions::Controller::Redirect.new("#{controller}##{action} not found!") unless route
       params = options[:params]?
       location, params = route.not_nil!.substitute_keys_in_path(params)
       status = options[:status]? || 302

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -28,13 +28,10 @@ module Amber::Controller
     def self.from_controller_action(controller : String, action : Symbol, **options)
       router = Amber::Router::Router.instance
       route = router.match_by_controller_action(controller, action)
-      if params = options[:params]?
-        location, params = route.not_nil!.parse_params(params)
-        status = options[:status]? || 302
-        new(location, status: status, params: params, flash: options[:flash]?)
-      else
-        raise Exceptions::Controller::Redirect.new("#{controller}##{action} not found!")
-      end
+      params = options[:params]?
+      location, params = route.not_nil!.substitute_keys_in_path(params)
+      status = options[:status]? || 302
+      new(location, status: status, params: params, flash: options[:flash]?)
     end
 
     def initialize(@location, @status = 302, @params = nil, @flash = nil)
@@ -62,7 +59,7 @@ module Amber::Controller
     end
 
     private def set_flash(controller)
-      controller.flash.merge!(flash.not_nil!) if !flash.nil?
+      controller.flash.merge!(flash.not_nil!) unless flash.nil?
     end
   end
 end

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -1,6 +1,23 @@
 module Amber::Controller
-  # This class writes the redirect URL to the response headers and parses params.
-  class LocationRedirect
+  module RedirectMethods
+    def redirect_to(location : String, **args)
+      Redirector.new(location, **args).redirect(self)
+    end
+
+    def redirect_to(action : Symbol, **args)
+      Redirector.from_controller_action(controller_name, action, **args).redirect(self)
+    end
+
+    def redirect_to(controller : Symbol, action : Symbol, **args)
+      Redirector.from_controller_action(controller.to_s, action, **args).redirect(self)
+    end
+
+    def redirect_back(**args)
+      Redirector.new(request.headers["Referer"].to_s, **args).redirect(self)
+    end
+  end
+
+  class Redirector
     getter location, status, params, flash
 
     @location : String
@@ -8,54 +25,44 @@ module Amber::Controller
     @params : Hash(String, String)? = nil
     @flash : Hash(String, String)? = nil
 
+    def self.from_controller_action(controller : String, action : Symbol, **options)
+      router = Amber::Router::Router.instance
+      route = router.match_by_controller_action(controller, action)
+      if params = options[:params]?
+        location, params = route.not_nil!.parse_params(params)
+        status = options[:status]? || 302
+        new(location, status: status, params: params, flash: options[:flash]?)
+      else
+        raise Exceptions::Controller::Redirect.new("#{controller}##{action} not found!")
+      end
+    end
+
     def initialize(@location, @status = 302, @params = nil, @flash = nil)
       raise_redirect_error(location) if location.empty?
     end
 
-    def redirect(for context)
-      response = context.response
-      context.flash.merge!(flash.not_nil!) if !flash.nil?
-      raise_redirect_error(location) unless location.url? || location.chars.first == '/'
-      set_location(response, location, status, params)
-    end
-
-    private def set_location(response, location, status = 302, params : _ = nil)
+    def redirect(controller)
+      set_flash(controller)
       url_path = encode_query_string(location, params)
-      response.headers.add "Location", url_path
-      response.status_code = status
+      controller.response.headers.add "Location", url_path
+      controller.halt!(status, "Redirecting to #{url_path}")
     end
 
-    def encode_query_string(location, params)
-      return location + "?" + HTTP::Params.encode(params).to_s if params
+    private def encode_query_string(location, params)
+      if !params.nil? && !params.empty?
+        return location + "?" + HTTP::Params.encode(params).to_s
+      end
       location
     end
 
-    def raise_redirect_error(location)
-      raise Exceptions::Controller::Redirect.new(location)
-    end
-  end
-
-  module RedirectFactory
-    def redirect_to(location : String, **args)
-      LocationRedirect.new(location, **args).redirect(context)
-      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
+    private def raise_redirect_error(location)
+      if (!location.url? || !location.chars.first == '/')
+        raise Exceptions::Controller::Redirect.new(location)
+      end
     end
 
-    # Redirects to the specified controller, action
-    def redirect_to(controller : Symbol, action : Symbol, **args)
-      LocationRedirect.new("/#{controller}/#{action}", **args).redirect(context)
-      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
-    end
-
-    # Redirects within the same controller
-    def redirect_to(action : Symbol, **args)
-      LocationRedirect.new("/#{controller_name}/#{action}", **args).redirect(context)
-      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
-    end
-
-    def redirect_back(**args)
-      LocationRedirect.new(request.headers["Referer"], status: 302).redirect(context)
-      halt!(response.status_code, "Redirecting to #{response.headers["Location"]}")
+    private def set_flash(controller)
+      controller.flash.merge!(flash.not_nil!) if !flash.nil?
     end
   end
 end

--- a/src/amber/controller/redirect.cr
+++ b/src/amber/controller/redirect.cr
@@ -18,10 +18,13 @@ module Amber::Controller
   end
 
   class Redirector
+    DEFAULT_STATUS_CODE = 302
+    LOCATION_HEADER     = "Location"
+
     getter location, status, params, flash
 
     @location : String
-    @status : Int32 = 302
+    @status : Int32 = DEFAULT_STATUS_CODE
     @params : Hash(String, String)? = nil
     @flash : Hash(String, String)? = nil
 
@@ -31,18 +34,18 @@ module Amber::Controller
       raise Exceptions::Controller::Redirect.new("#{controller}##{action} not found!") unless route
       params = options[:params]?
       location, params = route.not_nil!.substitute_keys_in_path(params)
-      status = options[:status]? || 302
+      status = options[:status]? || DEFAULT_STATUS_CODE
       new(location, status: status, params: params, flash: options[:flash]?)
     end
 
-    def initialize(@location, @status = 302, @params = nil, @flash = nil)
+    def initialize(@location, @status = DEFAULT_STATUS_CODE, @params = nil, @flash = nil)
       raise_redirect_error(location) if location.empty?
     end
 
     def redirect(controller)
       set_flash(controller)
       url_path = encode_query_string(location, params)
-      controller.response.headers.add "Location", url_path
+      controller.response.headers.add LOCATION_HEADER, url_path
       controller.halt!(status, "Redirecting to #{url_path}")
     end
 

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -36,12 +36,14 @@ module Amber
       handler.call(context)
     end
 
-    def parse_params(params)
+    def substitute_keys_in_path(params : Hash(String, String)? = nil)
       result = resource.dup
-      params.each do |k, v|
-        if result.includes?(":#{k}")
-          result = result.gsub(":#{k}", v)
-          params.delete(k)
+      if !params.nil?
+        params.each do |k, v|
+          if result.includes?(":#{k}")
+            result = result.gsub(":#{k}", v)
+            params.delete(k)
+          end
         end
       end
       {result, params}

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -37,7 +37,7 @@ module Amber
     end
 
     def substitute_keys_in_path(params : Hash(String, String)? = nil)
-      result = resource.dup
+      result = scope.to_s + resource.dup
       if !params.nil?
         params.each do |k, v|
           if result.includes?(":#{k}")

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -49,7 +49,7 @@ module Amber
       {result, params}
     end
 
-    def match(controller, action)
+    def match?(controller, action)
       self.controller.downcase == "#{controller}controller" && self.action == action
     end
   end

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -35,5 +35,20 @@ module Amber
     def call(context)
       handler.call(context)
     end
+
+    def parse_params(params)
+      result = resource.dup
+      params.each do |k, v|
+        if result.includes?(":#{k}")
+          result = result.gsub(":#{k}", v)
+          params.delete(k)
+        end
+      end
+      {result, params}
+    end
+
+    def match(controller, action)
+      self.controller.downcase == "#{controller}controller" && self.action == action
+    end
   end
 end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -57,11 +57,11 @@ module Amber
 
       def match_by_controller_action(controller, action, node = @routes.root)
         route = node.payload
-        if route.match(controller, action)
+        if route.match?(controller, action)
           return route
         else
           node.children.each do |current_node|
-            return current_node.payload if current_node.payload.match(controller, action)
+            return current_node.payload if current_node.payload.match?(controller, action)
             match_by_controller_action(controller, action, current_node)
           end
         end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -55,6 +55,18 @@ module Amber
         match(request.method, request.path)
       end
 
+      def match_by_controller_action(controller, action, node = @routes.root)
+        route = node.payload
+        if route.match(controller, action)
+          return route
+        else
+          node.children.each do |current_node|
+            return current_node.payload if current_node.payload.match(controller, action)
+            match_by_controller_action(controller, action, current_node)
+          end
+        end
+      end
+
       def all
         root_node = @routes.root
         all_routes = {} of String => String
@@ -72,12 +84,12 @@ module Amber
         end
       end
 
-      private def merge_params(params, context)
-        params.each { |k, v| context.params.add(k.to_s, v) }
-      end
-
       def match(http_verb, resource) : Radix::Result(Amber::Route)
         @routes.find build_node(http_verb, resource)
+      end
+
+      private def merge_params(params, context)
+        params.each { |k, v| context.params.add(k.to_s, v) }
       end
 
       private def build_node(http_verb : Symbol | String, resource : String)


### PR DESCRIPTION
Issue: https://github.com/amber-crystal/amber/issues/169
Issue:  https://github.com/amber-crystal/amber/issues/77

Redirect_to is rather limited in quite a few cases. Most resourceful routes will fail.

### Description of the Change

* Looks in the routes for the correct controller action resource path and if given will parse the path params.

```crystal
# config/routes.cr
get "/users/:id", UsersController, :show

# Within controller
redirect_to(controller: users, action: show, params: { "id" => "1", "utm" => "value" })

# Redirects to
"/users/1?utm=value"
```

This adds a match_by_controller_action(controller, action) method to Amber::Router::Router and performs a lookup when a match is found it returns the route. Then a `parse_params(params)` call can be made on the router to replace the resource params with actual values.