### PR TITLE
Adds useful methods to Context

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -33,11 +33,6 @@ module Amber::Controller
     end
 
     describe "#session" do
-      it "responds to session" do
-        controller = build_controller
-        controller.responds_to?(:session).should eq true
-      end
-
       it "sets a session value" do
         controller = build_controller
         controller.session["name"] = "David"

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -2,19 +2,27 @@ require "../../../spec_helper"
 
 module Amber::Controller
   describe Base do
-    describe "#cookies" do
-      it "responds to cookies" do
-        controller = build_controller
-
-        controller.responds_to?(:cookies).should eq true
-      end
-    end
-
-    describe "#redirect_to" do
-      it "responds to redirect_to" do
-        controller = build_controller
-        controller.responds_to?(:redirect_to).should eq true
-      end
+    it "responds to context methods" do
+      controller = build_controller
+      controller.responds_to?(:redirect_to).should eq true
+      controller.responds_to?(:cookies).should eq true
+      controller.responds_to?(:format).should eq true
+      controller.responds_to?(:port).should eq true
+      controller.responds_to?(:requested_url).should eq true
+      controller.responds_to?(:session).should eq true
+      controller.responds_to?(:invalid_route?).should eq true
+      controller.responds_to?(:valve).should eq true
+      controller.responds_to?(:request_handler).should eq true
+      controller.responds_to?(:route).should eq true
+      controller.responds_to?(:websocket?).should eq true
+      controller.responds_to?(:invalid_route?).should eq true
+      controller.responds_to?(:get?).should eq true
+      controller.responds_to?(:post?).should eq true
+      controller.responds_to?(:patch?).should eq true
+      controller.responds_to?(:put?).should eq true
+      controller.responds_to?(:delete?).should eq true
+      controller.responds_to?(:head?).should eq true
+      controller.responds_to?(:client_ip).should eq true
     end
 
     describe "#redirect_back" do
@@ -25,23 +33,19 @@ module Amber::Controller
     end
 
     describe "#session" do
-      it "responds to cookies" do
+      it "responds to session" do
         controller = build_controller
-
         controller.responds_to?(:session).should eq true
       end
 
       it "sets a session value" do
         controller = build_controller
-
         controller.session["name"] = "David"
-
         controller.session["name"].should eq "David"
       end
 
       it "has a session id" do
         controller = build_controller
-
         controller.session.id.not_nil!.size.should eq 36
       end
     end
@@ -143,29 +147,6 @@ module Amber::Controller
           controller.run_after_filter(:index)
 
           controller.total.should eq 2
-        end
-      end
-    end
-
-    describe "#redirect_back" do
-      context "and has a valid referrer" do
-        it "sets the correct response headers" do
-          hello_controller = build_controller("/world")
-
-          hello_controller.redirect_back
-          response = hello_controller.response
-
-          response.headers["Location"].should eq "/world"
-        end
-      end
-
-      context "and does not have a referrer" do
-        it "raisees an error" do
-          hello_controller = build_controller
-
-          expect_raises Exceptions::Controller::Redirect do
-            hello_controller.redirect_back
-          end
         end
       end
     end

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -23,6 +23,8 @@ module Amber::Controller
       controller.responds_to?(:delete?).should eq true
       controller.responds_to?(:head?).should eq true
       controller.responds_to?(:client_ip).should eq true
+      controller.responds_to?(:request).should eq true
+      controller.responds_to?(:response).should eq true
     end
 
     describe "#redirect_back" do

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -169,4 +169,53 @@ describe HTTP::Server::Context do
     context.params["title"].should eq "title field"
     context.params["_csrf"].should eq "PcCFp4oKJ1g-hZ-P7-phg0alC51pz7Pl12r0ZOncgxI"
   end
+
+  {% for request_method in HTTP::Server::Context::METHODS %}
+  describe "{{request_method.id}}" do
+    it "returns true when request matches {{request_method.id}}" do
+      request = HTTP::Request.new("{{request_method.id}}", "/")
+      context = create_context(request)
+      context.{{request_method.id}}?.should eq true
+    end
+
+    it "returns false when request does not match {{request_method.id}}" do
+       request = HTTP::Request.new("INVALID", "/")
+       context = create_context(request)
+       context.{{request_method.id}}?.should eq false
+    end
+  end
+  {% end %}
+
+  describe "#requested_url" do
+    it "returns the url requested by the client" do
+      url = "http://www.requested-url.com/hello"
+      request = HTTP::Request.new("GET", url)
+      context = create_context(request)
+      context.requested_url.should eq url
+    end
+  end
+
+  describe "port" do
+    it "gets the port from the requested URL" do
+      url = "http://localhost:9450"
+      request = HTTP::Request.new("GET", url)
+      context = create_context(request)
+      context.port.should eq 9450
+    end
+  end
+
+  describe "#format" do
+    {html:  "text/html",
+     xml:   "application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+     xhtml: "application/xhtml+xml",
+     ics:   "text/calendar"}.each do |format, content_type|
+      it "gets request format for #{content_type}" do
+        headers = HTTP::Headers.new
+        headers[HTTP::Server::Context::FORMAT_HEADER] = content_type
+        request = HTTP::Request.new("GET", "/", headers)
+        context = create_context(request)
+        context.format.should eq format.to_s
+      end
+    end
+  end
 end

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -218,4 +218,53 @@ describe HTTP::Server::Context do
       end
     end
   end
+
+  describe "#client_ip" do
+	HTTP::Server::Context::IP_ADDRESS_HEADERS.each do |header|
+	  it "gets client ip from #{header} headers" do
+		ip_address = "102.168.35.88"
+		headers = HTTP::Headers.new
+		headers[header] = ip_address
+		request = HTTP::Request.new("GET", "/", headers)
+		context = create_context(request)
+		context.client_ip.should eq ip_address
+	  end
+
+	  it "gets client ip from #{header} headers" do
+		ip_address = "102.168.35.88"
+		headers = HTTP::Headers.new
+		headers[header.tr("_", "-")] = ip_address
+		request = HTTP::Request.new("GET", "/", headers)
+		context = create_context(request)
+		context.client_ip.should eq ip_address
+	  end
+
+	  it "gets client ip from #{header} headers" do
+		ip_address = "102.168.35.88"
+		headers = HTTP::Headers.new
+		headers["HTTP_#{header}"] = ip_address
+		request = HTTP::Request.new("GET", "/", headers)
+		context = create_context(request)
+		context.client_ip.should eq ip_address
+	  end
+
+	  it "gets client ip from #{header} headers" do
+		ip_address = "102.168.35.88"
+		headers = HTTP::Headers.new
+		headers["Http-#{header}"] = ip_address
+		request = HTTP::Request.new("GET", "/", headers)
+		context = create_context(request)
+		context.client_ip.should eq ip_address
+	  end
+
+	  it "gets client ip from #{header} headers" do
+		ip_address = "102.168.35.88"
+		headers = HTTP::Headers.new
+		headers["HTTP-#{header}"] = ip_address
+		request = HTTP::Request.new("GET", "/", headers)
+		context = create_context(request)
+		context.client_ip.should eq ip_address
+	  end
+	end
+  end
 end

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -14,6 +14,10 @@ module Amber::Controller
     protected getter context : HTTP::Server::Context
     protected getter params : Amber::Validators::Params
 
+    delegate :cookies, :format, :flash, :port, :requested_url, :session, :invalid_route, :valve,
+             :request_handler, :route, :websocket?, :invalid_route?, :get?, :post?, :patch?,
+             :put?, :delete?, :head?, :client_ip, to: context
+
     def initialize(@context : HTTP::Server::Context)
       @request = context.request
       @response = context.response
@@ -21,18 +25,13 @@ module Amber::Controller
       @params = Amber::Validators::Params.new(@raw_params)
     end
 
-    def cookies
-      context.cookies
-    end
-
-    def flash
-      context.flash
-    end
-
-    def session
-      context.session
-    end
-
+    # TODO: Move this method to Context
+    #
+    # Now that we are delegating to context we should be 
+    # able to move this method to the HTTP::Server context class
+    # Not doing it now because of some refactoring that needs to happen
+    # and is a little out of scope for this PR since it touches a lot of
+    # moving pieces
     def halt!(status_code : Int32 = 200, content = "")
       response.headers["Content-Type"] = "text/plain"
       response.status_code = status_code

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -8,26 +8,22 @@ module Amber::Controller
     include Callbacks
     include Helpers::Tag
 
-    protected getter request : HTTP::Request
-    protected getter response : HTTP::Server::Response
     protected getter raw_params : HTTP::Params
     protected getter context : HTTP::Server::Context
     protected getter params : Amber::Validators::Params
 
     delegate :cookies, :format, :flash, :port, :requested_url, :session, :invalid_route, :valve,
-             :request_handler, :route, :websocket?, :invalid_route?, :get?, :post?, :patch?,
-             :put?, :delete?, :head?, :client_ip, to: context
+      :request_handler, :route, :websocket?, :invalid_route?, :get?, :post?, :patch?,
+      :put?, :delete?, :head?, :client_ip, :request, :response, to: context
 
     def initialize(@context : HTTP::Server::Context)
-      @request = context.request
-      @response = context.response
       @raw_params = context.params
       @params = Amber::Validators::Params.new(@raw_params)
     end
 
     # TODO: Move this method to Context
     #
-    # Now that we are delegating to context we should be 
+    # Now that we are delegating to context we should be
     # able to move this method to the HTTP::Server context class
     # Not doing it now because of some refactoring that needs to happen
     # and is a little out of scope for this PR since it touches a lot of

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -16,7 +16,7 @@ end
 class HTTP::Server::Context
   METHODS            = %i(get post put patch delete head)
   FORMAT_HEADER      = "Accept"
-  IP_ADDRESS_HEADERS = {"REMOTE_ADDR", "CLIENT_IP", "X_FORWARDED_FOR", "X_FORWARDED", "X_CLUSTER_CLIENT_IP", "FORWARDED"}
+  IP_ADDRESS_HEADERS = %w(REMOTE_ADDR CLIENT_IP X_FORWARDED_FOR X_FORWARDED X_CLUSTER_CLIENT_IP FORWARDED)
 
   include Amber::Router::Files
   include Amber::Router::Session
@@ -102,10 +102,12 @@ class HTTP::Server::Context
   # but this value is easily spoofed.
   def client_ip
     headers = request.headers
-    IP_ADDRESS_HEADERS.find_value { |header|
+    val = {} of String => String
+    IP_ADDRESS_HEADERS.find { |header|
       dashed_header = header.tr("_", "-")
-      headers[header]? || headers[dashed_header]? || headers["HTTP_#{header}"]? || headers["Http-#{dashed_header}"]?
-    }.try &.split(',').first
+      val = headers[header]? || headers[dashed_header]? || headers["HTTP_#{header}"]? || headers["Http-#{dashed_header}"]?
+    }
+    val
   end
 
   protected def process_websocket_request

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -1,5 +1,15 @@
 require "./**"
 
+class HTTP::Request
+  def port
+    uri.port
+  end
+
+  def url
+    uri.to_s
+  end
+end
+
 # The Context holds the request and the response objects.  The context is
 # passed to each handler that will read from the request object and build a
 # response object.  Params and Session hash can be accessed from the Context.
@@ -61,20 +71,27 @@ class HTTP::Server::Context
 
   {% for method in METHODS %}
   def {{method.id}}?
-    request.method == {{method.id}}
+    request.method == "{{method.id}}"
   end
   {% end %}
 
   def format
-    Amber::Support::MimeTypes.format(headers[FORMAT_HEADER])
+    content_type = request.headers[FORMAT_HEADER].split(",").first
+    type = if content_type.includes?(";")
+             content_type.split(";").first
+           else
+             content_type
+           end
+
+    Amber::Support::MimeTypes.format(type)
   end
 
   def port
-    request.uri.port
+    request.port
   end
 
   def requested_url
-    request.uri.to_s
+    request.url
   end
 
   # Attemps to retrieve client IP Address from headers

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -197,7 +197,6 @@ module Amber
         "hqx"       => "application/mac-binhex40",
         "htc"       => "text/x-component",
         "htke"      => "application/vnd.kenameaapp",
-        "htm"       => "text/html",
         "html"      => "text/html",
         "hvd"       => "application/vnd.yamaha.hv-dic",
         "hvp"       => "application/vnd.yamaha.hv-voice",
@@ -629,6 +628,10 @@ module Amber
       def self.zip_types(path) # https://github.com/h5bp/server-configs-nginx/blob/master/nginx.conf
         [".htm", ".html", ".txt", ".css", ".js", ".svg", ".json", ".xml", ".otf", ".ttf", ".woff", ".woff2"].includes? File.extname(path)
       end
+
+	  def self.format(accepts)
+		MIME_TYPES.key?(accepts)
+	  end
     end
   end
 end

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -1,9 +1,9 @@
 module Amber
   module Support
     module MimeTypes
-      DEFAULT_MIME_TYPE = "application/octet-stream"
-	  ZIP_FILE_EXTENSIONS = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
-      MIME_TYPES = {
+      DEFAULT_MIME_TYPE   = "application/octet-stream"
+      ZIP_FILE_EXTENSIONS = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
+      MIME_TYPES          = {
         "123"       => "application/vnd.lotus-1-2-3",
         "3dml"      => "text/vnd.in3d.3dml",
         "3g2"       => "video/3gpp2",
@@ -629,9 +629,9 @@ module Amber
         ZIP_FILE_EXTENSIONS.includes? File.extname(path)
       end
 
-	  def self.format(accepts)
-	    MIME_TYPES.key?(accepts)
-	  end
+      def self.format(accepts)
+        MIME_TYPES.key?(accepts)
+      end
     end
   end
 end

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -2,7 +2,7 @@ module Amber
   module Support
     module MimeTypes
       DEFAULT_MIME_TYPE = "application/octet-stream"
-	  ZIP_FILE_EXTENTIONS = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
+	  ZIP_FILE_EXTENSIONS = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
       MIME_TYPES = {
         "123"       => "application/vnd.lotus-1-2-3",
         "3dml"      => "text/vnd.in3d.3dml",

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -2,7 +2,7 @@ module Amber
   module Support
     module MimeTypes
       DEFAULT_MIME_TYPE = "application/octet-stream"
-
+	  ZIP_FILE_EXTENTIONS = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
       MIME_TYPES = {
         "123"       => "application/vnd.lotus-1-2-3",
         "3dml"      => "text/vnd.in3d.3dml",
@@ -625,12 +625,12 @@ module Amber
         MIME_TYPES.fetch(format, fallback)
       end
 
-      def self.zip_types(path) # https://github.com/h5bp/server-configs-nginx/blob/master/nginx.conf
-        [".htm", ".html", ".txt", ".css", ".js", ".svg", ".json", ".xml", ".otf", ".ttf", ".woff", ".woff2"].includes? File.extname(path)
+      def self.zip_types(path)
+        ZIP_FILE_EXTENSIONS.includes? File.extname(path)
       end
 
 	  def self.format(accepts)
-		MIME_TYPES.key?(accepts)
+	    MIME_TYPES.key?(accepts)
 	  end
     end
   end


### PR DESCRIPTION
Issue: https://github.com/amber-crystal/amber/issues/180

The request object contains a lot of useful information about the
request coming in from the client. To get a full list of the available
methods, refer to the Crystal API Documentation
https://crystal-lang.org/api/0.23.0/HTTP/Request.html

This adds several useful methods

* format to determine The content type requested by the client.
(JSON, XML, HTML etc)
* get?, post?, patch?, put?, delete?, head? Returns true if the
HTTP method is GET/POST/PATCH/PUT/DELETE/HEAD.
* port The port number (integer) used for the request.
* requested_url The entire URL used for the request.
* client_ip The IP Address of the client. This does not attempt to get
the actual machine remote IP Address but rather relies on request headers
to obtain it
