### PR TITLE
More Cleanup to Base controller

### DIFF
--- a/spec/amber/core/controller/base_spec.cr
+++ b/spec/amber/core/controller/base_spec.cr
@@ -10,12 +10,10 @@ module Amber::Controller
       controller.responds_to?(:port).should eq true
       controller.responds_to?(:requested_url).should eq true
       controller.responds_to?(:session).should eq true
-      controller.responds_to?(:invalid_route?).should eq true
       controller.responds_to?(:valve).should eq true
       controller.responds_to?(:request_handler).should eq true
       controller.responds_to?(:route).should eq true
       controller.responds_to?(:websocket?).should eq true
-      controller.responds_to?(:invalid_route?).should eq true
       controller.responds_to?(:get?).should eq true
       controller.responds_to?(:post?).should eq true
       controller.responds_to?(:patch?).should eq true

--- a/src/amber/core/controller/base.cr
+++ b/src/amber/core/controller/base.cr
@@ -8,34 +8,19 @@ module Amber::Controller
     include Callbacks
     include Helpers::Tag
 
-    protected getter raw_params : HTTP::Params
     protected getter context : HTTP::Server::Context
     protected getter params : Amber::Validators::Params
 
-    delegate :cookies, :format, :flash, :port, :requested_url, :session, :invalid_route, :valve,
-      :request_handler, :route, :websocket?, :invalid_route?, :get?, :post?, :patch?,
-      :put?, :delete?, :head?, :client_ip, :request, :response, to: context
+    delegate :cookies, :format, :flash, :port, :requested_url, :session, :valve,
+      :request_handler, :route, :websocket?, :get?, :post?, :patch?,
+      :put?, :delete?, :head?, :client_ip, :request, :response, :halt!, to: context
 
     def initialize(@context : HTTP::Server::Context)
-      @raw_params = context.params
-      @params = Amber::Validators::Params.new(@raw_params)
-    end
-
-    # TODO: Move this method to Context
-    #
-    # Now that we are delegating to context we should be
-    # able to move this method to the HTTP::Server context class
-    # Not doing it now because of some refactoring that needs to happen
-    # and is a little out of scope for this PR since it touches a lot of
-    # moving pieces
-    def halt!(status_code : Int32 = 200, content = "")
-      response.headers["Content-Type"] = "text/plain"
-      response.status_code = status_code
-      context.content = content
+      @params = Amber::Validators::Params.new(context.params)
     end
 
     def controller_name
-      self.class.name.downcase.gsub("controller", "")
+      self.class.name.gsub(/Controller/i, "")
     end
   end
 end

--- a/src/amber/core/router/context.cr
+++ b/src/amber/core/router/context.cr
@@ -52,10 +52,6 @@ class HTTP::Server::Context
     @flash ||= Amber::Router::Flash.from_session_value(session.fetch(Amber::Pipe::Flash::PARAM_KEY, "{}"))
   end
 
-  def invalid_route?
-    !route.payload? && !router.socket_route_defined?(@request)
-  end
-
   def websocket?
     request.headers["Upgrade"]? == "websocket"
   end
@@ -108,6 +104,15 @@ class HTTP::Server::Context
       val = headers[header]? || headers[dashed_header]? || headers["HTTP_#{header}"]? || headers["Http-#{dashed_header}"]?
     }
     val
+  end
+
+  def halt!(status_code : Int32 = 200, @content = "")
+    response.headers["Content-Type"] = "text/plain"
+    response.status_code = status_code
+  end
+
+  protected def invalid_route?
+    !route.payload? && !router.socket_route_defined?(@request)
   end
 
   protected def process_websocket_request


### PR DESCRIPTION

### Requirements
Continuing cleaning routing

### Description of the Change
- Moves halt! method from controller to context
- Removes unnecessary delegate to invalid_route?
- Removes the raw_params, rarely used and if needed is accessible thru
the context.params

### Benefits
Removing unnecessary variables and code
