### PR TITLE
make db drivers a dependency (for now)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -59,7 +59,6 @@ dependencies:
   spinner:
     github: elorest/spinner 
 
-development_dependencies:
   pg:
     github: will/crystal-pg
 


### PR DESCRIPTION
### Description of the Change

This addresses issue #196.  Micrate currently requires the 3 drivers and so we need to move these to dependencies in order for them to be installed for the ability to build `amber` on the client Docker image.

### Alternate Designs

We should look at fixing this dependency with Micrate so it doesn't require the driver and instead only require the base `db` library.  Until then, this is a workaround.

### Why Should This Be In Core?

So that Docker Images can be built and used by our users.

### Benefits

fixes Docker build.

### Possible Drawbacks

We already are requiring many shards that our user's probably don't need in order to build the amber_cmd.  We need to be careful on how many shards are required.  We don't want to end up like `node_modules` and have hundreds of unrelated libraries.
