### PR TITLE
Add ArchLinux on installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Ensure you have the necessary dependencies:
 - These are necessary to compile the CLI:
 - `sudo apt-get build-essential libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev`
 
+##### For ArchLinux & derivates
+- Install the CLI from [AUR package](https://aur.archlinux.org/packages/amber/). Dependencies are automatically installed.
+- `yaourt -S amber`
+
 <!-- WIP: ##### For RedHat & CentOS
 - `sudo yum groupinstall 'Development Tools' `
 - `sudo yum install readline-devel sqlite-devel openssl-devel libyaml-devel gc-devel libevent-devel` -->

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ Ensure you have the necessary dependencies:
 - These are necessary to compile the CLI:
 - `sudo apt-get build-essential libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev`
 
-##### For ArchLinux & derivates
-- Install the CLI from [AUR package](https://aur.archlinux.org/packages/amber/). Dependencies are automatically installed.
-- `yaourt -S amber`
-
 <!-- WIP: ##### For RedHat & CentOS
 - `sudo yum groupinstall 'Development Tools' `
 - `sudo yum install readline-devel sqlite-devel openssl-devel libyaml-devel gc-devel libevent-devel` -->
@@ -66,6 +62,10 @@ $ git clone git@github.com:amber-crystal/amber.git
 $ cd amber/
 $ make
 ```
+
+##### For ArchLinux & derivates
+- Install the CLI from [AUR package](https://aur.archlinux.org/packages/amber/). Dependencies are automatically installed.
+- `yaourt -S amber`
 
 You should now be able to run `amber` in the command line.
 


### PR DESCRIPTION
### Description of the Change

Adds ArchLinux to Installation section.

### Alternate Designs

Nop

### Why Should This Be In Core?

Support for other distro Linux.

### Benefits

ArchLinux users can install Amber easily

### Possible Drawbacks

Nop

### Applicable Issues

Are AUR dependencies ok? see: https://github.com/faustinoaq/amber-aur/blob/master/PKGBUILD#L9

I think [crystal](https://www.archlinux.org/packages/community/x86_64/crystal/) and [shards](https://www.archlinux.org/packages/community/x86_64/shards/) install almost all dependencies. Also ArchLinux has a lot of libraries installed by default.

