### PR TITLE
Fixes Flaky spec

### DIFF
--- a/spec/amber/cli/commands_spec.cr
+++ b/spec/amber/cli/commands_spec.cr
@@ -38,12 +38,9 @@ module Amber::CLI
         MainCommand.run ["new", TESTING_APP, "--deps"]
         Dir.cd(TESTING_APP)
         MainCommand.run ["generate", "scaffold", "Animal", "name:string"]
-        `sed -i '24s/github/path/g' shard.yml`
-        `sed -i '24s/amber-crystal/../g' ./shard.yml`
-        `sed -i '24s/amber//g' ./shard.yml`
-        puts "Done! Setting amber context to Test"
+        prepare_yaml(Dir.current)
+        `rm shard.lock`
         `shards build`
-        `crystal spec`
 
         File.exists?("bin/#{TESTING_APP}").should be_true
       end
@@ -99,4 +96,10 @@ end
 
 def shard_yml
   YAML.parse(File.read("#{TESTING_APP}/shard.yml"))
+end
+
+def prepare_yaml(path)
+  shard = File.read("#{path}/shard.yml")
+  shard = shard.gsub(/github\:\samber\-crystal\/amber\n/, "path: ../")
+  File.write("#{path}/shard.yml", shard)
 end

--- a/src/amber/cli/templates/app/spec/spec_helper.cr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "amber"
+require "../src/controllers/application_controller"
 require "../src/controllers/**"
 require "../src/mailers/**"
 require "../src/models/**"


### PR DESCRIPTION
### Description of the Change
The current implementation of the command spec has a dependency on sed
command.

This addresses the issue by removing the sed dependency
Replaces the amber github string with a local path

### Benefits
With those changes we remove the external dependency on sed command and
allow us to run test consistently.

### Benefits

This test could serve as a regression test for the generated app.
