### PR TITLE
generate secret one time at creation

### DIFF
--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -7,4 +7,11 @@ Amber::Server.configure do |setting|
   setting.env = (ENV["AMBER_ENV"] ||= "development").to_s
   setting.log = ::Logger.new(STDOUT)
   setting.log.level = ::Logger::INFO
+
+  setting.session = {
+    :key       => "<%= @name %>.session",
+    :store     => :signed_cookie,
+    :expires   => 0,
+    :secret    => "<%= SecureRandom.hex(64) %>"
+  }
 end


### PR DESCRIPTION
### Description of the Change

Configure and generate a secret for the cookie session store. Currently the default "secret" is not secure and could lead to vulnerabilities.

### Alternate Designs

n/a

### Benefits

The user no longer needs to do this manually.

### Possible Drawbacks

n/a