### PR TITLE
Bug Fixe: Socket endpoint is not defined method error

### DIFF
--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -1,5 +1,9 @@
 require "../../spec_helper"
 
+struct UserSocket < Amber::WebSockets::ClientSocket; end
+
+struct RoomSocket < Amber::WebSockets::ClientSocket; end
+
 describe Amber::Server do
   describe ".configure" do
     it "starts the server" do
@@ -18,6 +22,28 @@ describe Amber::Server do
       settings.port.should eq 8080
       settings.env.should eq "development"
       settings.secret.should eq "some secret key"
+    end
+
+    it "defines socket endpoint" do
+      Amber::Server.settings.router.socket_routes = [] of NamedTuple(path: String, handler: Amber::WebSockets::Server::Handler)
+
+      Amber::Server.configure do |app|
+        pipeline :web do
+        end
+
+        routes :web do
+          websocket "/user", UserSocket
+          websocket "/room", RoomSocket
+        end
+      end
+
+      router = Amber::Server.settings.router
+      websockets = router.socket_routes
+
+      websockets[0][:path].should eq "/user"
+      websockets[0][:handler].is_a?(Amber::WebSockets::Server::Handler).should be_true
+      websockets[1][:path].should eq "/room"
+      websockets[1][:handler].is_a?(Amber::WebSockets::Server::Handler).should be_true
     end
   end
 end

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -59,10 +59,6 @@ module Amber
       server.listen(settings.port_reuse)
     end
 
-    def socket_endpoint(path, app_socket)
-      WebSockets::Server.create_endpoint(path, app_socket)
-    end
-
     private def version
       "[Amber #{Amber::VERSION}]".colorize(:light_cyan).to_s
     end

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -65,5 +65,9 @@ module Amber::DSL
         {% raise "Invalid route action '#{action}'" %}
       {% end %}
     end
+
+    def websocket(path, app_socket)
+      Amber::WebSockets::Server.create_endpoint(path, app_socket)
+    end
   end
 end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -5,7 +5,7 @@ module Amber
     # This is the main application handler all routers should finally hit this
     # handler.
     class Router
-      property :routes
+      property :routes, :socket_routes
 
       def initialize
         @routes = Radix::Tree(Route).new


### PR DESCRIPTION
## Bug Fixe: Socket endpoint is not defined method error

Issue: https://github.com/amber-crystal/amber/issues/223
### Description of the Change

When defining a socket endpoint it within route it currently
throws an error socket_endpoint method is not defined. This is due to
the fact that the socket_endpoint is not accessible through the routes

In order to correct the bug, a WebSocket method was defined in place of
socket_endpoint in DSL::Router

Changes:

- Adds WebSocket as a  method instead of macro to Router DSL (See #224)
- Adds specs to ensure socket endpoint are defined
- Removes socker_endpoint from Amber::Server
- Makes socket_routes public

## Possible Drawbacks
This changes the current API from socket_endpoint to WebSocket since
this naming was to honor proposed changes in
https://github.com/amber-crystal/amber/pull/224

