### PR TITLE
fix method signature to match Channel

### DIFF
--- a/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
+++ b/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
@@ -1,7 +1,10 @@
 class <%= @name.capitalize %>Channel < Amber::WebSockets::Channel
-  def handle_joined
+  def handle_joined(client_socket, message)
   end
 
-  def handle_message(client_socket, msg)
+  def handle_message(client_socket, message)
+  end
+
+  def handle_leave(client_socket)
   end
 end

--- a/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
+++ b/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
@@ -2,6 +2,6 @@ class <%= @name.capitalize %>Channel < Amber::WebSockets::Channel
   def handle_joined
   end
 
-  def handle_message(msg)
+  def handle_message(client_socket, msg)
   end
 end


### PR DESCRIPTION
### Description of the Change

This fixes issue #226 reported by @mixflame 

The method signature has changed to include the client_socket for handle message. 