### PR TITLE
Update docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Amber Crystal borrows concepts that already have been battle tested, successful,
 
 ## Read the Docs
 
-Documentation https://amber-crystal.gitbooks.io/amber/content/
+Documentation https://docs.ambercr.io
 
 
 ## Benchmark


### PR DESCRIPTION
### Description of the Change

Updates the README amber docs url to docs.ambercr.io

### Benefits

Shorter, easier to remember and branding

### Possible Drawbacks

DNS are mapping to gitbook
