### PR TITLE
[WIP] Bug Fix: Fixes parsing JSON from request body

### DIFF
--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -28,7 +28,7 @@ module Amber::Router
       if content_type = request.headers["Content-Type"]?
         parse_multipart if content_type.try(&.starts_with?(MULTIPART_FORM))
         parse_part(request.body) if content_type.try(&.starts_with?(URL_ENCODED_FORM))
-        parse_json if content_type == APPLICATION_JSON
+        parse_json if content_type.includes? APPLICATION_JSON
       end
     end
 


### PR DESCRIPTION
## Bug Fix: Fixes parsing JSON from request body

### Description of the Change

The MIME media type for JSON text is application/json. The default encoding is UTF-8. (Source: RFC 4627).

Currently, when parsing JSON params from request body it does not match content type with format  `application/json;charset=UTF-8`, this is because checking content_type with **==** will not match content type. Instead checking with **includes?**  to check for content type matches.

### Benefits

When sending XmlHttpRequests with **application/json** Amber can successfully parse the body to json.

### Possible Drawbacks

It would be great to build a content type string parser to validate better against the different possible content types.

### Todo

- [ ] Write specs to validate params parsing.
