### PR TITLE
Bug Fix: CLI console command

### DIFF
--- a/src/amber/cli/commands/console.cr
+++ b/src/amber/cli/commands/console.cr
@@ -13,7 +13,14 @@ module Amber::CLI
       end
 
       def run
-        libs = ["require \"amber\"", "require \"./src/controllers/*\"", "require \"./src/models/*\"", "require \"./src/mailers/*\"", "require \"./src/views/*\"", "require \"./config/*\""] of String
+        libs = [
+          %(require "amber"),
+          %(require "./src/controllers/application_controller"),
+          %(require "./src/controllers/*"),
+          %(require "./src/models/*"),
+          %(require "./src/mailers/*"),
+          %(require "./src/views/*"),
+        ]
         code = libs.join ';'
         Icr::Console.new(options.d?).start(code)
       end


### PR DESCRIPTION

### Description of the Change
Application controller was not being loaded in the correct order when using
`require "./src/controller/*"`.

To correct the error loaded application_controller first. Also did a little formatting for 
readability

### Possible Drawbacks

This will cause an error if application controller does not exists