### PR TITLE
Removes deprecated method config

### DIFF
--- a/src/amber/server/configuration.cr
+++ b/src/amber/server/configuration.cr
@@ -8,11 +8,6 @@ module Amber
       def self.configure
         with settings yield settings
       end
-      
-      # NOTE: Deprecated. Here so old releases work.
-      def config
-        with settings yield settings
-      end
 
       def self.settings
         Settings


### PR DESCRIPTION
Config method was replaced with Configure

### Description of the Change

The config method has been deprecated in favor of `settings` and `configure`
